### PR TITLE
[EDMT-77] 테스트 커버리지 검증 및 Jacoco 리포트 자동 등록 설정

### DIFF
--- a/.github/workflows/api-docs-page.yml
+++ b/.github/workflows/api-docs-page.yml
@@ -3,7 +3,8 @@ name: BE/DOCS - API Docs Build & Deploy
 on:
   workflow_dispatch:
   push:
-    branches: develop
+    branches:
+    - develop
 
 permissions:
   contents: write

--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -6,7 +6,7 @@ on:
       - develop
   push:
     branches:
-      - develop
+      - feat/EDMT-77
 
 permissions: write-all
 

--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: create secret config file
         run: |
           cd src/main/resources
-          echo "${{ secrets.APPLICATION_YML_DEV }}" > ./application-dev.yml
+          echo "${{ secrets.APPLICATION_DEV_YML }}" > ./application-dev.yml
 
       - name: Cache Gradle packages
         uses: actions/cache@v3

--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -1,4 +1,4 @@
-name: DEV CI
+name: CI - Test Coverage 검증
 
 on:
   pull_request:

--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-  push:
-    branches:
-      - feat/EDMT-77
 
 permissions: write-all
 

--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -9,6 +9,7 @@ permissions: write-all
 
 jobs:
   build:
+    environment: dev
     runs-on: ubuntu-latest
 
     defaults:
@@ -26,7 +27,7 @@ jobs:
       - name: create secret config file
         run: |
           cd src/main/resources
-          echo "${{ secrets.APPLICATION_DEV_YML }}" > ./application-dev.yml
+          echo "${{ secrets.APPLICATION_YML }}" > ./application-dev.yml
 
       - name: Cache Gradle packages
         uses: actions/cache@v3

--- a/.github/workflows/ci-pr-build-test.yml
+++ b/.github/workflows/ci-pr-build-test.yml
@@ -1,0 +1,65 @@
+name: DEV CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: create secret config file
+        run: |
+          cd src/main/resources
+          echo "${{ secrets.APPLICATION_YML_DEV }}" > ./application-dev.yml
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: ${{ github.workspace }}/build/test-results/**/*.xml
+
+      - name: Jacoco Report to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          title: "🌻Test Coverage Report"
+          update-comment: true

--- a/build.gradle
+++ b/build.gradle
@@ -88,11 +88,6 @@ bootJar {
     }
 }
 
-tasks.named('test') {
-    useJUnitPlatform()
-    finalizedBy jacocoTestReport
-}
-
 jacocoTestReport {
     executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
 
@@ -102,4 +97,3 @@ jacocoTestReport {
         csv.required.set(false)
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '4.0.4'
+    id 'jacoco'
 }
 
 group = 'com.edumate'
@@ -86,3 +87,19 @@ bootJar {
         into 'static/docs'
     }
 }
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+
+    reports {
+        html.required.set(false)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
+}
+


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-77]


## 👩‍💻 작업 내용
develop 브랜치에 대한 PR시 동작하는 GitHub Actions CI 워크플로를 작성했습니다.
- Gradle 기반 백엔드 프로젝트 빌드 및 테스트 자동화 설정
- Jacoco를 사용하여 테스트 커버리지 리포트 생성 및 PR 코멘트로 게시
- 테스트 실패 여부와 커버리지 기준(전체/변경 파일 70%)을 기준으로 PR 상태 체크 제공

## 📝 리뷰 요청 & 논의하고 싶은 내용
현재 테스트 커버리지 기준을 70%로 설정해놨는데, 후에 테스트코드 직접 작성해보면서 조정해나가면 될 것 같아요.
(보통 80%를 Maximum으로 설정한다고 합니다)

## 📸 스크린 샷 (선택)


[EDMT-77]: https://bbangbbangz.atlassian.net/browse/EDMT-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ