### PR TITLE
[EDMT-110] 특정 학생의 생기부 특정 항목 종합 글을 불러오는 API 구현

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -8,16 +8,47 @@ operation::student-record/update-success[snippets="path-parameters,http-request,
 
 ==== 실패: 잘못된 생기부 항목 타입
 
-operation::student-record/update-fail/invalid-record-type[snippets="http-request,http-response"]
+operation::student-record/fail/invalid-record-type[snippets="http-request,http-response"]
 
 ==== 실패: 잘못된 학기 양식
 
-operation::student-record/update-fail/invalid-semester[snippets="http-request,http-response"]
+operation::student-record/fail/invalid-semester[snippets="http-request,http-response"]
 
 ==== 실패: 해당 학기에 해당 유저의 존재하지 않는 생기부
 
-operation::student-record/update-fail/member-record-not-found[snippets="http-request,http-response"]
+operation::student-record/fail/member-record-not-found[snippets="http-request,http-response"]
 
 ==== 실패: 특정 학생의 생기부가 존재하지 않음
 
-operation::student-record/update-fail/record-not-found[snippets="http-request,http-response"]
+operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
+
+==== 실패: 유효하지 않은 요청 값
+
+include::{snippets}/student-record/update-fail/missing-description/http-request.adoc[]
+include::{snippets}/student-record/update-fail/missing-semester/http-request.adoc[]
+include::{snippets}/student-record/update-fail/negative-byte-count/http-request.adoc[]
+include::{snippets}/student-record/update-fail/missing-semester/http-response.adoc[]
+
+=== 생활기록부 종합 글 불러오기
+
+==== 성공
+
+operation::student-record/get-success[snippets="path-parameters,query-parameters,http-request,http-response"]
+
+==== 실패: 잘못된 생기부 항목 타입
+
+operation::student-record/fail/invalid-record-type[snippets="http-request,http-response"]
+
+==== 실패: 잘못된 학기 양식
+
+operation::student-record/fail/invalid-semester[snippets="http-request,http-response"]
+
+==== 실패: 해당 학기에 해당 유저의 존재하지 않는 생기부
+
+operation::student-record/fail/member-record-not-found[snippets="http-request,http-response"]
+
+==== 실패: 특정 학생의 생기부가 존재하지 않음
+
+operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
+
+

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -5,12 +5,15 @@ import com.edumate.eduserver.common.code.CommonSuccessCode;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
 import com.edumate.eduserver.studentrecord.facade.StudentRecordFacade;
+import com.edumate.eduserver.studentrecord.facade.response.StudentRecordDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,5 +29,12 @@ public class StudentRecordController {
                                                  @RequestBody @Valid StudentRecordCreateRequest request) {
         studentRecordFacade.updateStudentRecord(1, recordType, recordId, request); // 멤버 아이디 하드코딩
         return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
+    @GetMapping("/student-records/{recordType}/{recordId}")
+    public ApiResponse<StudentRecordDetailResponse> getStudentRecord(@PathVariable final StudentRecordType recordType,
+                                                                     @PathVariable final long recordId,
+                                                                     @RequestParam(defaultValue = "2025-1") final String semester) {
+        return ApiResponse.success(CommonSuccessCode.OK, studentRecordFacade.getStudentRecord(1, recordType, recordId, semester)); // 멤버 아이디 하드코딩
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -2,7 +2,9 @@ package com.edumate.eduserver.studentrecord.facade;
 
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
+import com.edumate.eduserver.studentrecord.facade.response.StudentRecordDetailResponse;
 import com.edumate.eduserver.studentrecord.service.StudentRecordService;
+import com.edumate.eduserver.studentrecord.service.dto.StudentRecordDetailDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,10 @@ public class StudentRecordFacade {
     public void updateStudentRecord(final long memberId, final StudentRecordType recordType, final long recordId,
                                     final StudentRecordCreateRequest request) {
         studentRecordService.update(memberId, recordType, recordId, request.semester().trim(), request.description().trim(), request.byteCount());
+    }
 
+    public StudentRecordDetailResponse getStudentRecord(final long memberId, final StudentRecordType recordType, final long recordId, final String semester) {
+        StudentRecordDetailDto recordDetailDto = studentRecordService.get(memberId, recordType, recordId, semester.trim());
+        return StudentRecordDetailResponse.of(recordDetailDto.recordDetailId(), recordDetailDto.description(), recordDetailDto.byteCount());
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/response/StudentRecordDetailResponse.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/response/StudentRecordDetailResponse.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.studentrecord.facade.response;
+
+public record StudentRecordDetailResponse(
+        long recordDetailId,
+        String description,
+        int byteCount
+) {
+    public static StudentRecordDetailResponse of(final long recordDetailId, final String description, final int byteCount) {
+        return new StudentRecordDetailResponse(recordDetailId, description, byteCount);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -9,6 +9,7 @@ import com.edumate.eduserver.studentrecord.exception.StudentRecordDetailNotFound
 import com.edumate.eduserver.studentrecord.exception.code.StudentRecordErrorCode;
 import com.edumate.eduserver.studentrecord.repository.MemberStudentRecordRepository;
 import com.edumate.eduserver.studentrecord.repository.StudentRecordDetailRepository;
+import com.edumate.eduserver.studentrecord.service.dto.StudentRecordDetailDto;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,12 @@ public class StudentRecordService {
         MemberStudentRecord memberStudentRecord = findMemberStudentRecord(memberId, recordType, semester);
         StudentRecordDetail existingDetail = findRecordDetailById(recordId, memberStudentRecord);
         existingDetail.updateContent(description, byteCount);
+    }
+
+    public StudentRecordDetailDto get(final long memberId, final StudentRecordType recordType, final long recordId, final String semester) {
+        validateSemesterPattern(semester);
+        MemberStudentRecord memberStudentRecord = findMemberStudentRecord(memberId, recordType, semester);
+        return StudentRecordDetailDto.of(findRecordDetailById(recordId, memberStudentRecord));
     }
 
     private void validateSemesterPattern(final String semester) {

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/dto/StudentRecordDetailDto.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/dto/StudentRecordDetailDto.java
@@ -1,0 +1,13 @@
+package com.edumate.eduserver.studentrecord.service.dto;
+
+import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
+
+public record StudentRecordDetailDto(
+        long recordDetailId,
+        String description,
+        int byteCount
+) {
+    public static StudentRecordDetailDto of(final StudentRecordDetail recordDetail) {
+        return new StudentRecordDetailDto(recordDetail.getId(), recordDetail.getDescription(), recordDetail.getByteCount());
+    }
+}

--- a/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
@@ -2,6 +2,8 @@ package com.edumate.eduserver.studentrecord.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
@@ -9,6 +11,7 @@ import com.edumate.eduserver.studentrecord.exception.InvalidSemesterFormatExcept
 import com.edumate.eduserver.studentrecord.exception.MemberStudentRecordNotFoundException;
 import com.edumate.eduserver.studentrecord.exception.StudentRecordDetailNotFoundException;
 import com.edumate.eduserver.studentrecord.repository.StudentRecordDetailRepository;
+import com.edumate.eduserver.studentrecord.service.dto.StudentRecordDetailDto;
 import com.edumate.eduserver.util.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +43,26 @@ class StudentRecordServiceTest extends ServiceTest {
         // then
         StudentRecordDetail updated = studentRecordDetailRepository.findById(studentRecordId).get();
         assertThat(updated.getDescription()).isEqualTo(newDescription);
+    }
+
+    @Test
+    @DisplayName("특정 학생의 특정 생기부 항목에 대한 종합 내용을 불러온다.")
+    void test() {
+        // given
+        long memberId = defaultTeacher.getId();
+        StudentRecordType recordType = StudentRecordType.ABILITY_DETAIL;
+        long studentRecordId = defaultRecordDetail.getId();
+        String semester = "2025-1";
+
+        // when
+        StudentRecordDetailDto recordDetail = studentRecordService.get(memberId, recordType, studentRecordId, semester);
+
+        // then
+        assertAll(
+                () -> assertEquals(studentRecordId, recordDetail.recordDetailId()),
+                () -> assertEquals(defaultRecordDetail.getDescription(), recordDetail.description()),
+                () -> assertEquals(defaultRecordDetail.getByteCount(), recordDetail.byteCount())
+        );
     }
 
     @Test


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-110]

## 👩‍💻 작업 내용
특정 학생의 생활기록부 특정 항목의 종합 글 내용을 불러오는 API를 구현했습니다.
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용
test코드는 시간이 없어서, RestDcos 생성을 위한 controllerTest랑 로직 테스트를 위한 serviceTest만 작성했습니다.
Semester 파라미터 값, 혹시나 null 값으로 들어왔을 때를 대비해서, defaultValue를 하드코딩해놨는데, 좋은 방법은 아닌 것 같아서 고민 중입니다.
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📸 스크린 샷 (선택)
<img width="432" alt="image" src="https://github.com/user-attachments/assets/ef5db620-62fd-4e05-8e9a-e5666ccdf62a" />



[EDMT-110]: https://bbangbbangz.atlassian.net/browse/EDMT-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new API endpoint to retrieve detailed student record information by record type, record ID, and semester.
  - Expanded documentation to include retrieval operations and clarified failure response categories for student record APIs.

- **Bug Fixes**
  - Unified and reorganized failure response operation IDs in the API documentation for consistency.

- **Tests**
  - Introduced new tests to verify successful retrieval of student record details via the new endpoint.
  - Updated test descriptions and improved documentation paths for failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->