### PR TITLE
[EDMT-152] SecurityConfig에 권한별 URL 접근 제한 및 필터 체인 설정 적용

### DIFF
--- a/coderabbit.yaml
+++ b/coderabbit.yaml
@@ -1,6 +1,0 @@
-language: "ko-KR"
-tone_instructions: "부드럽고 친절한 어조로 이야기해주세요"
-early_access: false
-enable_free_tier: true
-reviews:
-  profile: "assertive"

--- a/coderabbit.yaml
+++ b/coderabbit.yaml
@@ -1,0 +1,6 @@
+language: "ko-KR"
+tone_instructions: "부드럽고 친절한 어조로 이야기해주세요"
+early_access: false
+enable_free_tier: true
+reviews:
+  profile: "assertive"

--- a/src/main/java/com/edumate/eduserver/auth/exception/IllegalTokenException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/IllegalTokenException.java
@@ -5,7 +5,7 @@ import com.edumate.eduserver.common.exception.UnauthorizedException;
 
 public class IllegalTokenException extends UnauthorizedException {
 
-    public IllegalTokenException(final AuthErrorCode errorCode, final String message) {
-        super(errorCode, String.format(errorCode.getMessage(), message));
+    public IllegalTokenException(final AuthErrorCode errorCode) {
+        super(errorCode);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/exception/IllegalTokenTypeException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/IllegalTokenTypeException.java
@@ -3,9 +3,9 @@ package com.edumate.eduserver.auth.exception;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.common.exception.UnauthorizedException;
 
-public class ExpiredTokenException extends UnauthorizedException {
+public class IllegalTokenTypeException extends UnauthorizedException {
 
-    public ExpiredTokenException(final AuthErrorCode errorCode) {
+    public IllegalTokenTypeException(final AuthErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/exception/InvalidSignatureTokenException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/InvalidSignatureTokenException.java
@@ -3,9 +3,9 @@ package com.edumate.eduserver.auth.exception;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.common.exception.UnauthorizedException;
 
-public class ExpiredTokenException extends UnauthorizedException {
+public class InvalidSignatureTokenException extends UnauthorizedException {
 
-    public ExpiredTokenException(final AuthErrorCode errorCode) {
+    public InvalidSignatureTokenException(final AuthErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -15,10 +15,12 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_PASSWORD_FORMAT("EDMT-4000105", "영문, 숫자, 특수문자 중 2종류 이상을 포함해야하며 같은 문자를 3번 이상 연속해서 사용할 수 없습니다."),
 
     // 401 Unauthorized,
-    INVALID_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 %s 토큰입니다."),
-    EXPIRED_TOKEN("EDMT-4010102", "이미 만료된 %s 토큰입니다."),
+    INVALID_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),
+    EXPIRED_TOKEN("EDMT-4010102", "이미 만료된 토큰입니다."),
     UNAUTHORIZED("EDMT-4010103", "인증되지 않은 사용자입니다."),
     MISSED_TOKEN("EDMT-4010104", "인증 토큰이 누락되었습니다."),
+    INVALID_TOKEN_TYPE("EDMT-4010105", "잘못된 유형의 토큰입니다. 요청에는 엑세스 토큰이 필요합니다."),
+    INVALID_SIGNATURE_TOKEN("EDMT-4010106", "토큰의 서명이 유효하지 않습니다."),
 
     // 403 Forbidden
     FORBIDDEN("EDMT-4030101", "권한이 부족한 사용자입니다."),

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -20,6 +20,9 @@ public enum AuthErrorCode implements ErrorCode {
     UNAUTHORIZED("EDMT-4010103", "인증되지 않은 사용자입니다."),
     MISSED_TOKEN("EDMT-4010104", "인증 토큰이 누락되었습니다."),
 
+    // 403 Forbidden
+    FORBIDDEN("EDMT-4030101", "권한이 부족한 사용자입니다."),
+
     // 404 Not Found,
     AUTH_CODE_NOT_FOUND("EDMT-4040101", "유효한 인증 코드가 존재하지 않습니다."),
 

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
@@ -7,6 +7,8 @@ import com.edumate.eduserver.auth.exception.InvalidSignatureTokenException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +29,11 @@ public class JwtValidator {
             validateClaims(claims, type);
         } catch (ExpiredJwtException e) {
             throw new ExpiredTokenException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE);
         } catch (SignatureException e) {
             throw new InvalidSignatureTokenException(AuthErrorCode.INVALID_SIGNATURE_TOKEN);
-        }
-        catch (IllegalTokenException | IllegalTokenTypeException e) {
+        } catch (IllegalTokenException | IllegalTokenTypeException e) {
             throw e;
         } catch (Exception e) {
             log.error("Token validation failed: {}", e.getMessage());

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
@@ -2,12 +2,17 @@ package com.edumate.eduserver.auth.security.jwt;
 
 import com.edumate.eduserver.auth.exception.ExpiredTokenException;
 import com.edumate.eduserver.auth.exception.IllegalTokenException;
+import com.edumate.eduserver.auth.exception.IllegalTokenTypeException;
+import com.edumate.eduserver.auth.exception.InvalidSignatureTokenException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtValidator {
@@ -21,11 +26,15 @@ public class JwtValidator {
             Claims claims = jwtParser.parseClaims(token);
             validateClaims(claims, type);
         } catch (ExpiredJwtException e) {
-            throw getExpiredTokenException(type);
-        } catch (IllegalTokenException e) {
+            throw new ExpiredTokenException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (SignatureException e) {
+            throw new InvalidSignatureTokenException(AuthErrorCode.INVALID_SIGNATURE_TOKEN);
+        }
+        catch (IllegalTokenException | IllegalTokenTypeException e) {
             throw e;
         } catch (Exception e) {
-            throw getInvalidTokenException(type);
+            log.error("Token validation failed: {}", e.getMessage());
+            throw e;
         }
     }
 
@@ -34,26 +43,10 @@ public class JwtValidator {
         String parsedTokenType = claims.get(TOKEN_TYPE_CLAIM, String.class);
 
         if (memberUuid == null || memberUuid.isBlank()) {
-            throw new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE, parsedTokenType);
+            throw new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE);
         }
         if (!expectedType.getType().equals(parsedTokenType)) {
-            throw new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE, parsedTokenType);
-        }
-    }
-
-    private ExpiredTokenException getExpiredTokenException(final TokenType type) {
-        if (type == TokenType.ACCESS) {
-            return new ExpiredTokenException(AuthErrorCode.EXPIRED_TOKEN, type.getType());
-        } else {
-            return new ExpiredTokenException(AuthErrorCode.EXPIRED_TOKEN, type.getType());
-        }
-    }
-
-    private IllegalTokenException getInvalidTokenException(final TokenType type) {
-        if (type == TokenType.ACCESS) {
-            return new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE, type.getType());
-        } else {
-            return new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE, type.getType());
+            throw new IllegalTokenTypeException(AuthErrorCode.INVALID_TOKEN_TYPE);
         }
     }
 }

--- a/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.edumate.eduserver.common.config;
 import com.edumate.eduserver.auth.security.jwt.JwtParser;
 import com.edumate.eduserver.auth.security.jwt.JwtValidator;
 import com.edumate.eduserver.common.security.CustomPasswordEncoder;
+import com.edumate.eduserver.common.security.JwtAccessDeniedHandler;
 import com.edumate.eduserver.common.security.JwtAuthenticationEntryPoint;
 import com.edumate.eduserver.common.security.filter.ExceptionHandlerFilter;
 import com.edumate.eduserver.common.security.filter.JwtAuthenticationFilter;
@@ -26,12 +27,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final MemberAuthenticationService memberAuthService;
     private final JwtValidator jwtValidator;
     private final JwtParser jwtParser;
 
     private static final String[] AUTH_WHITELIST = {
             "/api/v1/auth/signup",
+            "/api/v1/auth/login",
             "/api/v1/auth/reissue",
             "/api/v1/auth/verify-email",
             "/actuator/health"
@@ -42,21 +45,21 @@ public class SecurityConfig {
     };
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(sessionManagementConfigurer ->
-                        sessionManagementConfigurer
-                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .exceptionHandling(exceptionHandlingConfigurer ->
-                        exceptionHandlingConfigurer
-                                .authenticationEntryPoint(jwtAuthenticationEntryPoint))
-                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry
-                                .anyRequest()
-                                .authenticated())
+                .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/v1/student-records/**").hasAnyRole("TEACHER", "ADMIN")
+                        .anyRequest().authenticated()
+                )
                 .addFilterBefore(new JwtAuthenticationFilter(memberAuthService, jwtValidator, jwtParser),
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)

--- a/src/main/java/com/edumate/eduserver/common/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/edumate/eduserver/common/security/JwtAccessDeniedHandler.java
@@ -33,7 +33,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setStatus(HttpStatus.FORBIDDEN.value());
         response.getWriter().write(objectMapper.writeValueAsString(
-                ApiResponse.fail(HttpStatus.UNAUTHORIZED.value(), errorCode.getCode(), errorCode.getMessage())));
+                ApiResponse.fail(HttpStatus.FORBIDDEN.value(), errorCode.getCode(), errorCode.getMessage())));
     }
 }
 

--- a/src/main/java/com/edumate/eduserver/common/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/edumate/eduserver/common/security/JwtAccessDeniedHandler.java
@@ -31,7 +31,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     private void setResponse(final HttpServletResponse response, final AuthErrorCode errorCode) throws IOException {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
         response.getWriter().write(objectMapper.writeValueAsString(
                 ApiResponse.fail(HttpStatus.UNAUTHORIZED.value(), errorCode.getCode(), errorCode.getMessage())));
     }

--- a/src/main/java/com/edumate/eduserver/common/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/edumate/eduserver/common/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,39 @@
+package com.edumate.eduserver.common.security;
+
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
+import com.edumate.eduserver.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(final HttpServletRequest request, final HttpServletResponse response,
+                       final AccessDeniedException accessDeniedException) throws IOException {
+        handleException(response);
+    }
+
+    private void handleException(final HttpServletResponse response) throws IOException {
+        setResponse(response, AuthErrorCode.FORBIDDEN);
+    }
+
+    private void setResponse(final HttpServletResponse response, final AuthErrorCode errorCode) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(
+                ApiResponse.fail(HttpStatus.UNAUTHORIZED.value(), errorCode.getCode(), errorCode.getMessage())));
+    }
+}
+

--- a/src/test/java/com/edumate/eduserver/auth/security/jwt/JwtValidatorTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/security/jwt/JwtValidatorTest.java
@@ -5,7 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.edumate.eduserver.auth.exception.ExpiredTokenException;
-import com.edumate.eduserver.auth.exception.IllegalTokenException;
+import com.edumate.eduserver.auth.exception.IllegalTokenTypeException;
+import com.edumate.eduserver.auth.exception.InvalidSignatureTokenException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -54,7 +55,7 @@ class JwtValidatorTest {
 
         // when & then
         assertThatThrownBy(() -> jwtValidator.validateToken(token, TokenType.ACCESS))
-                .isInstanceOf(IllegalTokenException.class);
+                .isInstanceOf(IllegalTokenTypeException.class);
     }
 
     @Test
@@ -93,6 +94,6 @@ class JwtValidatorTest {
 
         // then
         assertThatThrownBy(() -> jwtValidator.validateToken(token, TokenType.ACCESS))
-                .isInstanceOf(IllegalTokenException.class);
+                .isInstanceOf(InvalidSignatureTokenException.class);
     }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-152]


## 👩‍💻 작업 내용
Spring Security 인가(Authorization) 설정 및 역할 기반 접근 제어를 추가했습니다.
공지사항의 경우, 인증/인가 여부와 상관없이 모든 사람이 볼 수 있어야 하기 때문에, filter chain을 타지 않도록 제외했습니다.
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📸 스크린 샷 (선택)
<img width="316" alt="image" src="https://github.com/user-attachments/assets/8255ddc0-5f03-42ce-a88f-7c662dcd18c2" />


[EDMT-152]: https://bbangbbangz.atlassian.net/browse/EDMT-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 잘못된 토큰 타입 및 유효하지 않은 서명에 대한 구체적인 인증 오류 메시지가 추가되었습니다.
  - 접근 거부 시 일관된 JSON 형식의 403 응답이 제공됩니다.

- **버그 수정**
  - 토큰 검증 과정에서 발생하는 다양한 오류 상황에 대해 더 명확한 예외 처리가 적용되었습니다.

- **테스트**
  - 토큰 타입 오류 및 서명 오류에 대한 테스트가 더 세분화되어 검증됩니다.

- **문서화**
  - 인증 오류 메시지 및 코드가 보다 구체적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->