### PR TITLE
[EDMT-127] 학생 관리 페이지에서 학생 1명 추가하는 API를 구현한다.

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -64,3 +64,13 @@ operation::student-record/fail/member-record-not-found[snippets="http-response"]
 
 ==== 실패: 유효하지 않은 학기 형식
 operation::student-record/get-names-fail/invalid-semester-format[snippets=http-response]
+
+=== 생활기록부 한 명 추가
+
+==== 성공
+
+operation::student-record/create-one-success[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+
+==== 실패: 유효하지 않은 학기 형식
+
+operation::student-record/get-names-fail/invalid-semester-format[snippets=http-response]

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -3,6 +3,7 @@ package com.edumate.eduserver.studentrecord.controller;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberUuid;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
+import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordsCreateRequest;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
@@ -64,6 +65,14 @@ public class StudentRecordController {
                                                   @PathVariable final StudentRecordType recordType,
                                                   @RequestBody @Valid final StudentRecordsCreateRequest request) {
         studentRecordFacade.createStudentRecords(memberUuid.strip(), recordType, request.semester().strip(), request.studentRecords());
+        return ApiResponse.success(CommonSuccessCode.CREATED);
+    }
+
+    @PostMapping("/{recordType}/students")
+    public ApiResponse<Void> createStudentRecord(@MemberUuid final String memberUuid,
+                                                 @PathVariable final StudentRecordType recordType,
+                                                 @RequestBody @Valid final StudentRecordCreateRequest request) {
+        studentRecordFacade.createStudentRecord(memberUuid.strip(), recordType, request.semester().trim(), request.studentRecord()); // 멤버 아이디 하드코딩
         return ApiResponse.success(CommonSuccessCode.CREATED);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/request/StudentRecordCreateRequest.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/request/StudentRecordCreateRequest.java
@@ -1,0 +1,12 @@
+package com.edumate.eduserver.studentrecord.controller.request;
+
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
+import jakarta.validation.constraints.NotNull;
+
+public record StudentRecordCreateRequest(
+        @NotNull(message = "학기 정보는 필수입니다.")
+        String semester,
+        @NotNull(message = "추가할 생기부는 필수입니다.")
+        StudentRecordCreateInfo studentRecord
+) {
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/request/vo/StudentRecordCreateInfo.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/request/vo/StudentRecordCreateInfo.java
@@ -1,0 +1,15 @@
+package com.edumate.eduserver.studentrecord.controller.request.vo;
+
+public record StudentRecordCreateInfo(
+        String studentNumber,
+        String studentName,
+        String description,
+        int byteCount
+) {
+    public static StudentRecordCreateInfo of(final String studentNumber,
+                                             final String studentName,
+                                             final String description,
+                                             final int byteCount) {
+        return new StudentRecordCreateInfo(studentNumber, studentName, description, byteCount);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -2,6 +2,7 @@ package com.edumate.eduserver.studentrecord.facade;
 
 import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
@@ -55,5 +56,12 @@ public class StudentRecordFacade {
                                      final List<StudentRecordInfo> studentRecordInfos) {
         Member member = memberService.getMemberByUuid(memberUuid);
         studentRecordService.createStudentRecords(member.getId(), recordType, semester, studentRecordInfos);
+    }
+
+    @Transactional
+    public void createStudentRecord(final String memberUuid, final StudentRecordType recordType, final String semester,
+                                    final StudentRecordCreateInfo studentRecordCreateInfo) {
+        Member member = memberService.getMemberByUuid(memberUuid);
+        studentRecordService.createStudentRecord(member.getId(), recordType, semester, studentRecordCreateInfo);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -1,5 +1,6 @@
 package com.edumate.eduserver.studentrecord.service;
 
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.MemberStudentRecord;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
@@ -68,6 +69,16 @@ public class StudentRecordService {
                         INITIAL_DESCRIPTION, INITIAL_BYTE_COUNT))
                 .toList();
         studentRecordDetailRepository.saveAll(details);
+    }
+
+    @Transactional
+    public StudentRecordDetail createStudentRecord(final long memberId, final StudentRecordType recordType, final String semester,
+                                    final StudentRecordCreateInfo studentRecordCreateInfo) {
+        MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
+        StudentRecordDetail studentRecordDetail = StudentRecordDetail.create(memberStudentRecord,
+                studentRecordCreateInfo.studentNumber(), studentRecordCreateInfo.studentName(),
+                studentRecordCreateInfo.description(), studentRecordCreateInfo.byteCount());
+        return studentRecordDetailRepository.save(studentRecordDetail);
     }
 
     private void validatePermission(final MemberStudentRecord memberRecord, final long memberId) {

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -25,8 +25,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
+import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordsCreateRequest;
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
 import com.edumate.eduserver.studentrecord.exception.InvalidSemesterFormatException;
@@ -410,6 +412,45 @@ class StudentRecordControllerTest extends ControllerTest {
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("에러 코드"),
                                 fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("생기부 한 개를 성공적으로 저장한다.")
+    void insertStudentRecord() throws Exception {
+        // given
+        StudentRecordCreateRequest request = new StudentRecordCreateRequest(
+                "2025-1", new StudentRecordCreateInfo("2020123", "유태근", "프로그래밍 동아리에서 웹 프로젝트를 진행하며 백엔드 개발을 맡아 로그인 기능과 데이터 저장 기능을 구현함.", 149)
+        );
+        doNothing().when(studentRecordFacade)
+                .createStudentRecord(anyString(), any(StudentRecordType.class), anyString(), any());
+
+        // when & then
+        mockMvc.perform(post(BASE_URL + "/{recordType}/students", RECORD_TYPE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.code").value("EDMT-201"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "create-one-success",
+                        pathParameters(
+                                parameterWithName("recordType").description("생활기록부 항목 타입")
+                        ),
+                        requestFields(
+                                fieldWithPath("semester").description("학기 정보"),
+                                fieldWithPath("studentRecord").description("생활기록부 정보 객체"),
+                                fieldWithPath("studentRecord.studentNumber").description("학번"),
+                                fieldWithPath("studentRecord.studentName").description("학생 이름"),
+                                fieldWithPath("studentRecord.description").description("기록 내용"),
+                                fieldWithPath("studentRecord.byteCount").description("기록 데이터 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
                         )
                 ));
     }

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
@@ -112,6 +113,20 @@ class StudentRecordFacadeTest {
         willDoNothing().given(studentRecordService).createStudentRecords(500L, type, semester, infos);
         studentRecordFacade.createStudentRecords(memberUuid, type, semester, infos);
         verify(studentRecordService).createStudentRecords(500L, type, semester, infos);
+    }
+
+    @Test
+    @DisplayName("학생 기록 생성이 정상 동작한다.")
+    void createStudentRecord() {
+        String memberUuid = "uuid-5";
+        StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
+        String semester = "2024-2";
+        StudentRecordCreateInfo info = mock(StudentRecordCreateInfo.class);
+        Member member = mock(Member.class);
+        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(member.getId()).willReturn(500L);
+        studentRecordFacade.createStudentRecord(memberUuid, type, semester, info);
+        verify(studentRecordService).createStudentRecord(500L, type, semester, info);
     }
 }
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.MemberStudentRecord;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
@@ -160,5 +161,38 @@ class StudentRecordServiceTest extends ServiceTest {
         assertThatThrownBy(() ->
                 studentRecordService.update(otherMemberId, defaultRecordDetail.getId(), "변경된 내용", 15)
         ).isInstanceOf(UpdatePermissionDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("생활기록부 한 개를 생성한다.")
+    void createStudentRecord() {
+        // given
+        long memberId = 1L;
+        StudentRecordType recordType = StudentRecordType.ABILITY_DETAIL;
+        String semester = "2025-1";
+        String studentNumber = "2023002";
+        String studentName = "유태근";
+        String description = "생활기록부 내용";
+        int byteCount = 22;
+        StudentRecordCreateInfo studentRecordCreateInfo = StudentRecordCreateInfo.of(
+                studentNumber, studentName, description, byteCount
+        );
+
+        // when
+        StudentRecordDetail studentRecord = studentRecordService.createStudentRecord(memberId, recordType, semester,
+                studentRecordCreateInfo);
+
+        // then
+        MemberStudentRecord memberStudentRecord = memberStudentRecordRepository
+                .findByMemberIdAndStudentRecordTypeAndSemester(memberId, recordType, semester)
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(memberStudentRecord.getSemester()).isEqualTo(semester),
+                () -> assertThat(studentRecord.getStudentNumber()).isEqualTo(studentNumber),
+                () -> assertThat(studentRecord.getStudentName()).isEqualTo(studentName),
+                () -> assertThat(studentRecord.getDescription()).isEqualTo(description),
+                () -> assertThat(studentRecord.getByteCount()).isEqualTo(byteCount)
+        );
     }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-127]

## 👩‍💻 작업 내용

학생 1명 추가하는 API를 구현하고 작성된 코드에 대해 테스트 코드를 작성했습니다.


[EDMT-127]: https://bbangbbangz.atlassian.net/browse/EDMT-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 단일 학생 생활기록부를 생성할 수 있는 API 엔드포인트가 추가되었습니다.

- **문서화**
  - 학생 생활기록부 단일 추가 API에 대한 설명 및 예시가 문서에 추가되었습니다.

- **테스트**
  - 단일 학생 생활기록부 생성 기능에 대한 단위 및 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->