### PR TITLE
[EDMT-125] 학생 관리 페이지에서 학생 1명 수정하는 API를 구현한다.

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -74,3 +74,16 @@ operation::student-record/create-one-success[snippets="path-parameters,http-requ
 ==== 실패: 유효하지 않은 학기 형식
 
 operation::student-record/get-names-fail/invalid-semester-format[snippets=http-response]
+
+=== 생활기록부 한 명 수정
+
+==== 성공
+
+operation::student-record/update-overview-success[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+
+==== 실패: 특정 학생의 생기부가 존재하지 않음
+
+operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
+
+==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
+operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -4,6 +4,7 @@ import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberUuid;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
+import com.edumate.eduserver.studentrecord.controller.request.StudentRecordOverviewUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordsCreateRequest;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
@@ -14,6 +15,7 @@ import com.edumate.eduserver.studentrecord.facade.response.StudentRecordOverview
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -74,5 +76,14 @@ public class StudentRecordController {
                                                  @RequestBody @Valid final StudentRecordCreateRequest request) {
         studentRecordFacade.createStudentRecord(memberUuid.strip(), recordType, request.semester().trim(), request.studentRecord()); // 멤버 아이디 하드코딩
         return ApiResponse.success(CommonSuccessCode.CREATED);
+    }
+
+    @PatchMapping("/{recordId}")
+    public ApiResponse<Void> updateStudentRecordOverview(@MemberUuid final String memberUuid,
+                                                         @PathVariable final long recordId,
+                                                         @RequestBody @Valid final StudentRecordOverviewUpdateRequest request) {
+        studentRecordFacade.updateStudentRecordOverview(memberUuid.strip(), recordId, request.studentNumber(),
+                request.studentName(), request.description(), request.byteCount());
+        return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/request/StudentRecordOverviewUpdateRequest.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/request/StudentRecordOverviewUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.edumate.eduserver.studentrecord.controller.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record StudentRecordOverviewUpdateRequest(
+        @NotNull(message = "학번은 필수 입력 항목입니다.")
+        String studentNumber,
+        @NotNull(message = "학생 이름은 필수 입력 항목입니다.")
+        String studentName,
+        @NotNull(message = "생기부 내용은 필수 입력 항목입니다.")
+        String description,
+        @Min(value = 0, message = "바이트 수는 0 이상이어야 합니다.")
+        int byteCount
+) {
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/request/vo/StudentRecordUpdateInfo.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/request/vo/StudentRecordUpdateInfo.java
@@ -1,0 +1,15 @@
+package com.edumate.eduserver.studentrecord.controller.request.vo;
+
+public record StudentRecordUpdateInfo(
+        String studentNumber,
+        String studentName,
+        String description,
+        int byteCount
+) {
+    public static StudentRecordUpdateInfo of(final String studentNumber,
+                                             final String studentName,
+                                             final String description,
+                                             final int byteCount) {
+        return new StudentRecordUpdateInfo(studentNumber, studentName, description, byteCount);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
@@ -45,6 +45,13 @@ public class StudentRecordDetail extends BaseEntity {
         this.byteCount = byteCount;
     }
 
+    public void update(final String studentNumber, String studentName, String description, int byteCount) {
+        this.studentNumber = studentNumber;
+        this.studentName = studentName;
+        this.description = description;
+        this.byteCount = byteCount;
+    }
+
     @Builder
     private StudentRecordDetail(final MemberStudentRecord memberStudentRecord, final String studentNumber,
                                 final String studentName, final String description, final int byteCount) {

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -64,4 +64,12 @@ public class StudentRecordFacade {
         Member member = memberService.getMemberByUuid(memberUuid);
         studentRecordService.createStudentRecord(member.getId(), recordType, semester, studentRecordCreateInfo);
     }
+
+    @Transactional
+    public void updateStudentRecordOverview(final String memberUuid, final long recordId, final String studentNumber,
+                                            final String studentName, final String description, final int byteCount) {
+        Member member = memberService.getMemberByUuid(memberUuid);
+        studentRecordService.updateStudentRecordOverview(member.getId(), recordId, studentNumber, studentName,
+                description, byteCount);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -81,6 +81,14 @@ public class StudentRecordService {
         return studentRecordDetailRepository.save(studentRecordDetail);
     }
 
+    @Transactional
+    public void updateStudentRecordOverview(final long memberId, final long recordId, final String studentNumber,
+                                            final String studentName, final String description, final int byteCount) {
+        StudentRecordDetail existingDetail = getRecordDetailById(recordId);
+        validatePermission(existingDetail.getMemberStudentRecord(), memberId);
+        existingDetail.update(studentNumber, studentName, description, byteCount);
+    }
+
     private void validatePermission(final MemberStudentRecord memberRecord, final long memberId) {
         if (memberRecord.getMember().getId() != memberId) {
             throw new UpdatePermissionDeniedException(StudentRecordErrorCode.UPDATE_PERMISSION_DENIED);

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
+import com.edumate.eduserver.studentrecord.controller.request.StudentRecordOverviewUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordsCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
@@ -446,6 +448,47 @@ class StudentRecordControllerTest extends ControllerTest {
                                 fieldWithPath("studentRecord.studentName").description("학생 이름"),
                                 fieldWithPath("studentRecord.description").description("기록 내용"),
                                 fieldWithPath("studentRecord.byteCount").description("기록 데이터 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("학생 생활기록부 전체 내용을 성공적으로 업데이트 한다.")
+    void updateStudentRecordOverview() throws Exception {
+        // given
+        StudentRecordOverviewUpdateRequest request = new StudentRecordOverviewUpdateRequest(
+                "2020123",
+                "유태근",
+                "수정된 생활기록부 내용",
+                149
+        );
+
+        doNothing().when(studentRecordFacade)
+                .updateStudentRecordOverview(anyString(), anyLong(), anyString(), anyString(), anyString(), anyInt());
+
+        // when & then
+        mockMvc.perform(patch(BASE_URL + "/{recordId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-overview-success",
+                        pathParameters(
+                                parameterWithName("recordId").description("기록 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("studentNumber").description("학번"),
+                                fieldWithPath("studentName").description("학생 이름"),
+                                fieldWithPath("description").description("생기부 내용"),
+                                fieldWithPath("byteCount").description("기록 데이터 크기")
                         ),
                         responseFields(
                                 fieldWithPath("status").description("HTTP 상태 코드"),

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -128,5 +128,24 @@ class StudentRecordFacadeTest {
         studentRecordFacade.createStudentRecord(memberUuid, type, semester, info);
         verify(studentRecordService).createStudentRecord(500L, type, semester, info);
     }
+
+    @Test
+    @DisplayName("생활기록부 전체 수정이 정상 동작한다.")
+    void updateStudentRecordOverview() {
+        String memberUuid = "uuid-2";
+        long recordId = 2L;
+        String studentNumber = "20204567";
+        String studentName = "김철수";
+        String description = "리더십을 발휘하여 팀 프로젝트를 성공적으로 완수함.";
+        int byteCount = 120;
+        Member member = mock(Member.class);
+        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(member.getId()).willReturn(200L);
+        willDoNothing().given(studentRecordService)
+                .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
+        studentRecordFacade.updateStudentRecordOverview(memberUuid, recordId, studentNumber, studentName, description, byteCount);
+        verify(studentRecordService)
+                .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
+    }
 }
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
@@ -195,4 +195,43 @@ class StudentRecordServiceTest extends ServiceTest {
                 () -> assertThat(studentRecord.getByteCount()).isEqualTo(byteCount)
         );
     }
+
+    @Test
+    @DisplayName("생활기록부 한 개를 수정한다.")
+    void updateStudentRecordOverview() {
+        // given
+        long memberId = 1L;
+        StudentRecordType recordType = StudentRecordType.ABILITY_DETAIL;
+        String semester = "2025-1";
+        String originalStudentNumber = "2023002";
+        String originalStudentName = "유태근";
+        String originalDescription = "기존 내용";
+        int originalByteCount = 22;
+
+        StudentRecordCreateInfo createInfo = StudentRecordCreateInfo.of(
+                originalStudentNumber, originalStudentName, originalDescription, originalByteCount
+        );
+        StudentRecordDetail savedRecord = studentRecordService.createStudentRecord(memberId, recordType, semester, createInfo);
+        long recordId = savedRecord.getId();
+
+        String updatedStudentNumber = "2023111";
+        String updatedStudentName = "홍길동";
+        String updatedDescription = "수정된 생활기록부 내용";
+        int updatedByteCount = 45;
+
+        // when
+        studentRecordService.updateStudentRecordOverview(memberId, recordId,
+                updatedStudentNumber, updatedStudentName, updatedDescription, updatedByteCount);
+
+        // then
+        StudentRecordDetail updated = studentRecordDetailRepository.findById(recordId)
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(updated.getStudentNumber()).isEqualTo(updatedStudentNumber),
+                () -> assertThat(updated.getStudentName()).isEqualTo(updatedStudentName),
+                () -> assertThat(updated.getDescription()).isEqualTo(updatedDescription),
+                () -> assertThat(updated.getByteCount()).isEqualTo(updatedByteCount)
+        );
+    }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-125]


## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
학생 1명 수정하는 API를 구현하고 작성된 코드에 대해 테스트 코드를 작성했습니다.


[EDMT-125]: https://bbangbbangz.atlassian.net/browse/EDMT-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 학생 생활기록부의 개요(학생 번호, 이름, 설명, 바이트 수)를 한 번에 수정할 수 있는 PATCH API가 추가되었습니다.

- **Documentation**
    - 학생 생활기록부 단일 수정 기능에 대한 API 문서가 추가되었습니다.

- **Tests**
    - 학생 생활기록부 개요 수정 기능에 대한 컨트롤러, 서비스, 퍼사드 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->