### PR TITLE
[EDMT-126] 학생 관리 페이지에서 학생 1명 수정하는 API를 구현한다.

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -87,3 +87,16 @@ operation::student-record/fail/record-not-found[snippets="http-request,http-resp
 
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]
+
+=== 생활기록부 한 명 삭제
+
+==== 성공
+
+operation::student-record/delete-success[snippets="path-parameters,http-request,http-response,response-fields"]
+
+==== 실패: 특정 학생의 생기부가 존재하지 않음
+
+operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
+
+==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
+operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -14,6 +14,7 @@ import com.edumate.eduserver.studentrecord.facade.response.StudentRecordDetailRe
 import com.edumate.eduserver.studentrecord.facade.response.StudentRecordOverviewsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -84,6 +85,13 @@ public class StudentRecordController {
                                                          @RequestBody @Valid final StudentRecordOverviewUpdateRequest request) {
         studentRecordFacade.updateStudentRecordOverview(memberUuid.strip(), recordId, request.studentNumber(),
                 request.studentName(), request.description(), request.byteCount());
+        return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
+    @DeleteMapping("/{recordId}")
+    public ApiResponse<Void> deleteStudentRecord(@MemberUuid final String memberUuid,
+                                                 @PathVariable final long recordId) {
+        studentRecordFacade.deleteStudentRecord(memberUuid.strip(), recordId);
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
@@ -45,7 +45,8 @@ public class StudentRecordDetail extends BaseEntity {
         this.byteCount = byteCount;
     }
 
-    public void update(final String studentNumber, String studentName, String description, int byteCount) {
+    public void update(final String studentNumber, final String studentName, final String description,
+                       final int byteCount) {
         this.studentNumber = studentNumber;
         this.studentName = studentName;
         this.description = description;

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -72,4 +72,10 @@ public class StudentRecordFacade {
         studentRecordService.updateStudentRecordOverview(member.getId(), recordId, studentNumber, studentName,
                 description, byteCount);
     }
+
+    @Transactional
+    public void deleteStudentRecord(final String memberUuid, final long recordId) {
+        Member member = memberService.getMemberByUuid(memberUuid);
+        studentRecordService.deleteStudentRecord(member.getId(), recordId);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -74,6 +74,7 @@ public class StudentRecordService {
     @Transactional
     public StudentRecordDetail createStudentRecord(final long memberId, final StudentRecordType recordType, final String semester,
                                     final StudentRecordCreateInfo studentRecordCreateInfo) {
+        validateSemesterPattern(semester);
         MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
         StudentRecordDetail studentRecordDetail = StudentRecordDetail.create(memberStudentRecord,
                 studentRecordCreateInfo.studentNumber(), studentRecordCreateInfo.studentName(),

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -90,6 +90,13 @@ public class StudentRecordService {
         existingDetail.update(studentNumber, studentName, description, byteCount);
     }
 
+    @Transactional
+    public void deleteStudentRecord(final long memberId, final long recordId) {
+        StudentRecordDetail existingDetail = getRecordDetailById(recordId);
+        validatePermission(existingDetail.getMemberStudentRecord(), memberId);
+        studentRecordDetailRepository.deleteById(recordId);
+    }
+
     private void validatePermission(final MemberStudentRecord memberRecord, final long memberId) {
         if (memberRecord.getMember().getId() != memberId) {
             throw new UpdatePermissionDeniedException(StudentRecordErrorCode.UPDATE_PERMISSION_DENIED);

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -491,6 +492,33 @@ class StudentRecordControllerTest extends ControllerTest {
                                 fieldWithPath("studentName").description("학생 이름"),
                                 fieldWithPath("description").description("생기부 내용"),
                                 fieldWithPath("byteCount").description("기록 데이터 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("학생 생활기록부를 성공적으로 삭제한다.")
+    void deleteStudentRecord() throws Exception {
+        // given
+        long recordId = 1L;
+        doNothing().when(studentRecordFacade).deleteStudentRecord(anyString(), anyLong());
+
+        // when & then
+        mockMvc.perform(delete(BASE_URL + "/{recordId}", recordId)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "delete-success",
+                        pathParameters(
+                                parameterWithName("recordId").description("삭제할 생활기록부 ID")
                         ),
                         responseFields(
                                 fieldWithPath("status").description("HTTP 상태 코드"),

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -430,6 +430,7 @@ class StudentRecordControllerTest extends ControllerTest {
 
         // when & then
         mockMvc.perform(post(BASE_URL + "/{recordType}/students", RECORD_TYPE)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(request)))
                 .andDo(print())
@@ -473,6 +474,7 @@ class StudentRecordControllerTest extends ControllerTest {
 
         // when & then
         mockMvc.perform(patch(BASE_URL + "/{recordId}", 1L)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(request)))
                 .andDo(print())

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -147,5 +147,18 @@ class StudentRecordFacadeTest {
         verify(studentRecordService)
                 .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
     }
+
+    @Test
+    @DisplayName("생활기록부 삭제가 정상 동작한다.")
+    void deleteStudentRecordFacade() {
+        String memberUuid = "uuid-3";
+        long recordId = 3L;
+        Member member = mock(Member.class);
+        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(member.getId()).willReturn(300L);
+        willDoNothing().given(studentRecordService).deleteStudentRecord(300L, recordId);
+        studentRecordFacade.deleteStudentRecord(memberUuid, recordId);
+        verify(studentRecordService).deleteStudentRecord(300L, recordId);
+    }
 }
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
@@ -234,4 +234,24 @@ class StudentRecordServiceTest extends ServiceTest {
                 () -> assertThat(updated.getByteCount()).isEqualTo(updatedByteCount)
         );
     }
+
+    @Test
+    @DisplayName("생활기록부 한 개를 삭제한다.")
+    void deleteStudentRecordService() {
+        // given
+        long memberId = 1L;
+        StudentRecordType recordType = StudentRecordType.ABILITY_DETAIL;
+        String semester = "2025-1";
+        StudentRecordCreateInfo info = StudentRecordCreateInfo.of("2023002", "유태근", "삭제될 생기부", 22);
+
+        StudentRecordDetail created = studentRecordService.createStudentRecord(memberId, recordType, semester, info);
+        long recordId = created.getId();
+
+        // when
+        studentRecordService.deleteStudentRecord(memberId, recordId);
+
+        // then
+        boolean exists = studentRecordDetailRepository.findById(recordId).isPresent();
+        assertThat(exists).isFalse();
+    }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-126]


## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
학생 1명 삭제하는 API를 구현하고 작성된 코드에 대해 테스트 코드를 작성했습니다.



[EDMT-126]: https://bbangbbangz.atlassian.net/browse/EDMT-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 학생 기록을 삭제할 수 있는 기능이 추가되었습니다.

- **문서화**
    - 학생 기록 삭제 API에 대한 문서가 추가되어 성공 및 실패 응답 사례가 안내됩니다.

- **테스트**
    - 학생 기록 삭제 기능에 대한 컨트롤러, 서비스, 파사드 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->