### PR TITLE
[EDMT-160] 로그인, 로그아웃, 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -63,7 +63,7 @@ public class AuthController {
 
     @PatchMapping("/reissue")
     public ApiResponse<MemberReissueResponse> reissue(@RequestHeader(HttpHeaders.AUTHORIZATION) final String refreshToken) {
-        MemberReissueResponse response = authFacade.reissue(refreshToken);
+        MemberReissueResponse response = authFacade.reissue(refreshToken.strip());
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -5,16 +5,19 @@ import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
 import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
 import com.edumate.eduserver.auth.facade.AuthFacade;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
+import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberUuid;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -58,4 +61,9 @@ public class AuthController {
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
+    @PatchMapping("/reissue")
+    public ApiResponse<MemberReissueResponse> reissue(@RequestHeader(HttpHeaders.AUTHORIZATION) final String refreshToken) {
+        MemberReissueResponse response = authFacade.reissue(refreshToken);
+        return ApiResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.edumate.eduserver.auth.controller;
 
 import com.edumate.eduserver.auth.controller.request.EmailSendRequest;
+import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
 import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
 import com.edumate.eduserver.auth.facade.AuthFacade;
+import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
@@ -24,21 +26,27 @@ public class AuthController {
 
     @PostMapping("/email/send-verification")
     public ApiResponse<Void> sendVerificationEmail(@RequestBody @Valid final EmailSendRequest request) {
-        authFacade.sendVerificationEmail(request.memberUuid().trim());
+        authFacade.sendVerificationEmail(request.memberUuid().strip());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
     @GetMapping("/verify-email")
     public ApiResponse<Void> verifyEmail(@RequestParam("id") final String memberUuid,
                                          @RequestParam("code") final String verificationCode) {
-        authFacade.verifyEmailCode(memberUuid.trim(), verificationCode.trim());
+        authFacade.verifyEmailCode(memberUuid.strip(), verificationCode.strip());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
     @PostMapping("/signup")
     public ApiResponse<MemberSignUpResponse> signUp(@RequestBody @Valid final MemberSignUpRequest request) {
-        MemberSignUpResponse response = authFacade.signUp(request.email().trim(), request.password().trim(),
-                request.subject().trim(), request.school().trim());
+        MemberSignUpResponse response = authFacade.signUp(request.email().strip(), request.password().strip(),
+                request.subject().strip(), request.school().strip());
+        return ApiResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<MemberLoginResponse> login(@RequestBody @Valid final MemberLoginRequest request) {
+        MemberLoginResponse response = authFacade.login(request.email().strip(), request.password().strip());
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -7,10 +7,12 @@ import com.edumate.eduserver.auth.facade.AuthFacade;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.common.ApiResponse;
+import com.edumate.eduserver.common.annotation.MemberUuid;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,4 +51,11 @@ public class AuthController {
         MemberLoginResponse response = authFacade.login(request.email().strip(), request.password().strip());
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
+
+    @PatchMapping("/logout")
+    public ApiResponse<Void> logout(@MemberUuid final String memberUuid) {
+        authFacade.logout(memberUuid.strip());
+        return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
 }

--- a/src/main/java/com/edumate/eduserver/auth/controller/request/MemberLoginRequest.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/request/MemberLoginRequest.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.auth.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MemberLoginRequest(
+        @NotNull(message = "이메일은 필수 입력값입니다.")
+        String email,
+        @NotNull(message = "비밀번호는 필수 입력값입니다.")
+        String password
+) {
+}

--- a/src/main/java/com/edumate/eduserver/auth/controller/request/MemberLoginRequest.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/request/MemberLoginRequest.java
@@ -1,9 +1,11 @@
 package com.edumate.eduserver.auth.controller.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 
 public record MemberLoginRequest(
         @NotNull(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,
         @NotNull(message = "비밀번호는 필수 입력값입니다.")
         String password

--- a/src/main/java/com/edumate/eduserver/auth/domain/AuthorizationCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/domain/AuthorizationCode.java
@@ -79,11 +79,4 @@ public class AuthorizationCode {
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiredAt);
     }
-
-    public void updateCode(final String code) {
-        this.authorizationCode = code;
-        this.createdAt = LocalDateTime.now();
-        this.expiredAt = LocalDateTime.now().plusMinutes(MINUTES_TO_EXPIRE);
-        this.status = AuthorizeStatus.REVOKED;
-    }
 }

--- a/src/main/java/com/edumate/eduserver/auth/exception/MismatchedPasswordException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/MismatchedPasswordException.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.auth.exception;
+
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
+import com.edumate.eduserver.common.exception.BadRequestException;
+
+public class MismatchedPasswordException extends BadRequestException {
+
+    public MismatchedPasswordException(final AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/exception/MismatchedPasswordException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/MismatchedPasswordException.java
@@ -1,11 +1,11 @@
 package com.edumate.eduserver.auth.exception;
 
-import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.common.exception.BadRequestException;
+import com.edumate.eduserver.member.exception.code.MemberErrorCode;
 
 public class MismatchedPasswordException extends BadRequestException {
 
-    public MismatchedPasswordException(final AuthErrorCode errorCode) {
+    public MismatchedPasswordException(final MemberErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_CODE("EDMT-4000103", "유효하지 않은 인증 코드입니다."),
     INVALID_PASSWORD_LENGTH("EDMT-4000104", "비밀번호는 8자 이상 16자 이하로 입력해주세요."),
     INVALID_PASSWORD_FORMAT("EDMT-4000105", "영문, 숫자, 특수문자 중 2종류 이상을 포함해야하며 같은 문자를 3번 이상 연속해서 사용할 수 없습니다."),
+    MISMATCHED_PASSWORD("EDMT-4000106", "비밀번호가 일치하지 않습니다."),
 
     // 401 Unauthorized,
     INVALID_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -16,7 +16,8 @@ public enum AuthErrorCode implements ErrorCode {
     MISMATCHED_PASSWORD("EDMT-4000106", "비밀번호가 일치하지 않습니다."),
 
     // 401 Unauthorized,
-    INVALID_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),
+    INVALID_ACCESS_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN_VALUE("EDMT-4010107", "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_TOKEN("EDMT-4010102", "이미 만료된 토큰입니다."),
     UNAUTHORIZED("EDMT-4010103", "인증되지 않은 사용자입니다."),
     MISSED_TOKEN("EDMT-4010104", "인증 토큰이 누락되었습니다."),

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -13,7 +13,6 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_CODE("EDMT-4000103", "유효하지 않은 인증 코드입니다."),
     INVALID_PASSWORD_LENGTH("EDMT-4000104", "비밀번호는 8자 이상 16자 이하로 입력해주세요."),
     INVALID_PASSWORD_FORMAT("EDMT-4000105", "영문, 숫자, 특수문자 중 2종류 이상을 포함해야하며 같은 문자를 3번 이상 연속해서 사용할 수 없습니다."),
-    MISMATCHED_PASSWORD("EDMT-4000106", "비밀번호가 일치하지 않습니다."),
 
     // 401 Unauthorized,
     INVALID_ACCESS_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -16,6 +16,7 @@ import com.edumate.eduserver.auth.service.RandomCodeGenerator;
 import com.edumate.eduserver.auth.service.Token;
 import com.edumate.eduserver.auth.service.TokenService;
 import com.edumate.eduserver.member.domain.Member;
+import com.edumate.eduserver.member.exception.code.MemberErrorCode;
 import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.subject.domain.Subject;
 import com.edumate.eduserver.subject.service.SubjectService;
@@ -73,7 +74,7 @@ public class AuthFacade {
     public MemberLoginResponse login(final String email, final String password) {
         Member member = memberService.getMemberByEmail(email);
         if (!passwordEncoder.matches(password, member.getPassword())) {
-            throw new MismatchedPasswordException(AuthErrorCode.MISMATCHED_PASSWORD);
+            throw new MismatchedPasswordException(MemberErrorCode.MEMBER_NOT_FOUND);
         }
         Token token = tokenService.generateTokens(member);
         return MemberLoginResponse.of(token.accessToken(), token.refreshToken());
@@ -89,7 +90,7 @@ public class AuthFacade {
     public MemberReissueResponse reissue(final String inputRefreshToken) {
         String refreshToken = tokenService.getRemovedBearerPrefixToken(inputRefreshToken);
         jwtValidator.validateToken(refreshToken, TokenType.REFRESH);
-        String memberUuid= jwtParser.getMemberUuidFromToken(refreshToken, TokenType.REFRESH);
+        String memberUuid = jwtParser.getMemberUuidFromToken(refreshToken);
         Member member = memberService.getMemberByUuid(memberUuid);
         Token token = tokenService.generateTokens(member);
         return MemberReissueResponse.of(token.accessToken(), token.refreshToken());

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -69,6 +69,7 @@ public class AuthFacade {
         }
     }
 
+    @Transactional
     public MemberLoginResponse login(final String email, final String password) {
         Member member = memberService.getMemberByEmail(email);
         if (!passwordEncoder.matches(password, member.getPassword())) {

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -72,4 +72,10 @@ public class AuthFacade {
         String refreshToken = jwtGenerator.generateToken(member.getMemberUuid(), TokenType.REFRESH);
         return MemberLoginResponse.of(accessToken, refreshToken);
     }
+
+    @Transactional
+    public void logout(final String memberUuid) {
+        Member member = memberService.getMemberByUuid(memberUuid);
+        authService.logout(member);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -4,13 +4,17 @@ import com.edumate.eduserver.auth.exception.MemberAlreadyRegisteredException;
 import com.edumate.eduserver.auth.exception.MismatchedPasswordException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
+import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
-import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
+import com.edumate.eduserver.auth.security.jwt.JwtParser;
+import com.edumate.eduserver.auth.security.jwt.JwtValidator;
 import com.edumate.eduserver.auth.security.jwt.TokenType;
 import com.edumate.eduserver.auth.service.AuthService;
 import com.edumate.eduserver.auth.service.EmailService;
 import com.edumate.eduserver.auth.service.PasswordValidator;
 import com.edumate.eduserver.auth.service.RandomCodeGenerator;
+import com.edumate.eduserver.auth.service.Token;
+import com.edumate.eduserver.auth.service.TokenService;
 import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.subject.domain.Subject;
@@ -29,7 +33,9 @@ public class AuthFacade {
     private final AuthService authService;
     private final MemberService memberService;
     private final SubjectService subjectService;
-    private final JwtGenerator jwtGenerator;
+    private final TokenService tokenService;
+    private final JwtValidator jwtValidator;
+    private final JwtParser jwtParser;
     private final PasswordEncoder passwordEncoder;
     private final RandomCodeGenerator randomCodeGenerator;
 
@@ -48,16 +54,16 @@ public class AuthFacade {
     }
 
     @Transactional
-    public MemberSignUpResponse signUp(final String email, final String password, final String subjectName, final String school) {
+    public MemberSignUpResponse signUp(final String email, final String password, final String subjectName,
+                                       final String school) {
         authService.checkAlreadyRegistered(email);
         PasswordValidator.validate(password);
         String encodedPassword = passwordEncoder.encode(password);
         Subject subject = subjectService.getSubjectByName(subjectName);
         try {
             String memberUuid = memberService.saveMember(email, encodedPassword, subject, school);
-            String accessToken = jwtGenerator.generateToken(memberUuid, TokenType.ACCESS);
-            String refreshToken = jwtGenerator.generateToken(memberUuid, TokenType.REFRESH);
-            return MemberSignUpResponse.of(accessToken, refreshToken);
+            Token token = tokenService.generateTokens(memberService.getMemberByUuid(memberUuid));
+            return MemberSignUpResponse.of(token.accessToken(), token.refreshToken());
         } catch (DataIntegrityViolationException e) {
             throw new MemberAlreadyRegisteredException(AuthErrorCode.MEMBER_ALREADY_REGISTERED);
         }
@@ -68,14 +74,23 @@ public class AuthFacade {
         if (!passwordEncoder.matches(password, member.getPassword())) {
             throw new MismatchedPasswordException(AuthErrorCode.MISMATCHED_PASSWORD);
         }
-        String accessToken = jwtGenerator.generateToken(member.getMemberUuid(), TokenType.ACCESS);
-        String refreshToken = jwtGenerator.generateToken(member.getMemberUuid(), TokenType.REFRESH);
-        return MemberLoginResponse.of(accessToken, refreshToken);
+        Token token = tokenService.generateTokens(member);
+        return MemberLoginResponse.of(token.accessToken(), token.refreshToken());
     }
 
     @Transactional
     public void logout(final String memberUuid) {
         Member member = memberService.getMemberByUuid(memberUuid);
         authService.logout(member);
+    }
+
+    @Transactional
+    public MemberReissueResponse reissue(final String inputRefreshToken) {
+        String refreshToken = tokenService.getRemovedBearerPrefixToken(inputRefreshToken);
+        jwtValidator.validateToken(refreshToken, TokenType.REFRESH);
+        String memberUuid= jwtParser.getMemberUuidFromToken(refreshToken, TokenType.REFRESH);
+        Member member = memberService.getMemberByUuid(memberUuid);
+        Token token = tokenService.generateTokens(member);
+        return MemberReissueResponse.of(token.accessToken(), token.refreshToken());
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/facade/response/MemberLoginResponse.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/response/MemberLoginResponse.java
@@ -1,0 +1,10 @@
+package com.edumate.eduserver.auth.facade.response;
+
+public record MemberLoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static MemberLoginResponse of(final String accessToken, final String refreshToken) {
+        return new MemberLoginResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/facade/response/MemberReissueResponse.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/response/MemberReissueResponse.java
@@ -1,0 +1,10 @@
+package com.edumate.eduserver.auth.facade.response;
+
+public record MemberReissueResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static MemberReissueResponse of(final String accessToken, final String refreshToken) {
+        return new MemberReissueResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtParser.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtParser.java
@@ -22,6 +22,11 @@ public class JwtParser {
                 .getBody();
     }
 
+    public String getMemberUuidFromToken(final String refreshToken, final TokenType tokenType) {
+        Claims claims = parseClaims(refreshToken);
+        return claims.getSubject();
+    }
+
     private Key getSigningKey() {
         byte[] keyBytes = Base64.getDecoder().decode(jwtProperties.secretKey());
         return Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtParser.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtParser.java
@@ -22,7 +22,7 @@ public class JwtParser {
                 .getBody();
     }
 
-    public String getMemberUuidFromToken(final String refreshToken, final TokenType tokenType) {
+    public String getMemberUuidFromToken(final String refreshToken) {
         Claims claims = parseClaims(refreshToken);
         return claims.getSubject();
     }

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
@@ -30,7 +30,10 @@ public class JwtValidator {
         } catch (ExpiredJwtException e) {
             throw new ExpiredTokenException(AuthErrorCode.EXPIRED_TOKEN);
         } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-            throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
+            if (type == TokenType.ACCESS) {
+                throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
+            }
+            throw new IllegalTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN_VALUE);
         } catch (SignatureException e) {
             throw new InvalidSignatureTokenException(AuthErrorCode.INVALID_SIGNATURE_TOKEN);
         } catch (IllegalTokenException | IllegalTokenTypeException e) {

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
@@ -48,11 +48,15 @@ public class JwtValidator {
         String memberUuid = claims.getSubject();
         String parsedTokenType = claims.get(TOKEN_TYPE_CLAIM, String.class);
 
-        if (memberUuid == null || memberUuid.isBlank()) {
-            throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
-        }
         if (!expectedType.getType().equals(parsedTokenType)) {
             throw new IllegalTokenTypeException(AuthErrorCode.INVALID_TOKEN_TYPE);
+        }
+
+        if (memberUuid == null || memberUuid.isBlank()) {
+            if (expectedType == TokenType.ACCESS) {
+                throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
+            }
+            throw new IllegalTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN_VALUE);
         }
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtValidator.java
@@ -30,7 +30,7 @@ public class JwtValidator {
         } catch (ExpiredJwtException e) {
             throw new ExpiredTokenException(AuthErrorCode.EXPIRED_TOKEN);
         } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-            throw new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE);
+            throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
         } catch (SignatureException e) {
             throw new InvalidSignatureTokenException(AuthErrorCode.INVALID_SIGNATURE_TOKEN);
         } catch (IllegalTokenException | IllegalTokenTypeException e) {
@@ -46,7 +46,7 @@ public class JwtValidator {
         String parsedTokenType = claims.get(TOKEN_TYPE_CLAIM, String.class);
 
         if (memberUuid == null || memberUuid.isBlank()) {
-            throw new IllegalTokenException(AuthErrorCode.INVALID_TOKEN_VALUE);
+            throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
         }
         if (!expectedType.getType().equals(parsedTokenType)) {
             throw new IllegalTokenTypeException(AuthErrorCode.INVALID_TOKEN_TYPE);

--- a/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
@@ -22,6 +22,8 @@ public class AuthService {
     private final AuthorizationCodeRepository authorizationCodeRepository;
     private final MemberRepository memberRepository;
 
+    private static final String EMPTY_REFRESH_TOKEN = null;
+
     @Transactional
     public void verifyEmailCode(final Member member, final String inputCode) {
         AuthorizationCode authorizationCode = getValidCodeByMember(member.getId());
@@ -37,7 +39,7 @@ public class AuthService {
 
     @Transactional
     public void logout(final Member member) {
-        member.updateRefreshToken(null);
+        member.updateRefreshToken(EMPTY_REFRESH_TOKEN);
     }
 
     public void checkAlreadyRegistered(final String email) {

--- a/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
@@ -35,6 +35,11 @@ public class AuthService {
         authorizationCodeRepository.save(authorizationCode);
     }
 
+    @Transactional
+    public void logout(final Member member) {
+        member.updateRefreshToken(null);
+    }
+
     public void checkAlreadyRegistered(final String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new MemberAlreadyRegisteredException(AuthErrorCode.MEMBER_ALREADY_REGISTERED);

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -1,5 +1,7 @@
 package com.edumate.eduserver.auth.service;
 
+import com.edumate.eduserver.auth.exception.IllegalTokenException;
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
 import com.edumate.eduserver.auth.security.jwt.TokenType;
 import com.edumate.eduserver.member.domain.Member;
@@ -25,6 +27,9 @@ public class TokenService {
     }
 
     public String getRemovedBearerPrefixToken(final String token) {
-        return token.substring(BEARER_PREFIX.length());
+        if (token != null && token.startsWith(BEARER_PREFIX)) {
+            return token.substring(BEARER_PREFIX.length());
+        }
+        throw new IllegalTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN_VALUE);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -14,11 +14,17 @@ public class TokenService {
 
     private final JwtGenerator jwtGenerator;
 
+    private static final String BEARER_PREFIX = "Bearer ";
+
     @Transactional
     public Token generateTokens(final Member member) {
         String accessToken = jwtGenerator.generateToken(member.getMemberUuid(), TokenType.ACCESS);
         String refreshToken = jwtGenerator.generateToken(member.getMemberUuid(), TokenType.REFRESH);
         member.updateRefreshToken(refreshToken);
         return Token.of(accessToken, refreshToken);
+    }
+
+    public String getRemovedBearerPrefixToken(final String token) {
+        return token.substring(BEARER_PREFIX.length());
     }
 }

--- a/src/main/java/com/edumate/eduserver/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/member/exception/code/MemberErrorCode.java
@@ -11,7 +11,7 @@ public enum MemberErrorCode implements ErrorCode {
     INVALID_SCHOOL_TYPE("EDMT-4000401", "입력하신 %s는 유효하지 않습니다. MIDDLE, HIGH 중 하나를 입력해주세요."),
 
     // 404 Not Found
-    MEMBER_NOT_FOUND("EDMT-4040401", "해당 회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND("EDMT-4040401", "존재하지 않는 회원입니다. 회원가입을 진행해주세요.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
+++ b/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
@@ -8,5 +8,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByMemberUuid(String memberUuid);
 
+    Optional<Member> findByEmail(String email);
+
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -41,4 +41,9 @@ public class MemberService {
         return memberRepository.findByMemberUuid(memberUuid)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
+
+    public Member getMemberByEmail(final String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/test/java/com/edumate/eduserver/auth/facade/AuthFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/facade/AuthFacadeTest.java
@@ -1,10 +1,8 @@
 package com.edumate.eduserver.auth.facade;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -13,15 +11,14 @@ import static org.mockito.Mockito.verify;
 import com.edumate.eduserver.auth.exception.InvalidPasswordFormatException;
 import com.edumate.eduserver.auth.exception.InvalidPasswordLengthException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
-import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
-import com.edumate.eduserver.auth.security.jwt.TokenType;
 import com.edumate.eduserver.auth.service.AuthService;
 import com.edumate.eduserver.auth.service.EmailService;
 import com.edumate.eduserver.auth.service.RandomCodeGenerator;
+import com.edumate.eduserver.auth.service.TokenService;
+import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.subject.domain.Subject;
 import com.edumate.eduserver.subject.service.SubjectService;
-import com.edumate.eduserver.member.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +37,8 @@ class AuthFacadeTest {
     @Mock
     SubjectService subjectService;
     @Mock
+    TokenService tokenService;
+    @Mock
     JwtGenerator jwtGenerator;
     @Mock
     PasswordEncoder passwordEncoder;
@@ -52,32 +51,6 @@ class AuthFacadeTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-    }
-
-    @Test
-    @DisplayName("회원가입이 정상적으로 동작한다.")
-    void signUp() {
-        String email = "test@email.com";
-        String password = "Abc12345!";
-        String subjectName = "수학";
-        String school = "테스트고";
-        Subject subject = mock(Subject.class);
-        String encodedPassword = "encoded";
-        String memberUuid = "uuid-123";
-        String accessToken = "access-token";
-        String refreshToken = "refresh-token";
-
-        given(subjectService.getSubjectByName(subjectName)).willReturn(subject);
-        given(passwordEncoder.encode(password)).willReturn(encodedPassword);
-        willDoNothing().given(authService).checkAlreadyRegistered(email);
-        given(memberService.saveMember(email, encodedPassword, subject, school)).willReturn(memberUuid);
-        given(jwtGenerator.generateToken(memberUuid, TokenType.ACCESS)).willReturn(accessToken);
-        given(jwtGenerator.generateToken(memberUuid, TokenType.REFRESH)).willReturn(refreshToken);
-
-        MemberSignUpResponse response = authFacade.signUp(email, password, subjectName, school);
-
-        assertThat(response.accessToken()).isEqualTo(accessToken);
-        assertThat(response.refreshToken()).isEqualTo(refreshToken);
     }
 
     @Test

--- a/src/test/java/com/edumate/eduserver/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/notice/controller/NoticeControllerTest.java
@@ -124,7 +124,7 @@ class NoticeControllerTest extends ControllerTest {
         String category = NoticeCategory.NOTICE.getText();
         String title    = "테스트 공지 제목";
         String content  = "여기는 공지 상세 내용입니다.";
-        LocalDateTime createdAt = LocalDateTime.now();
+        LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 15, 30, 45);
 
         NoticeGetResponse noticeGetResponse = new NoticeGetResponse(
                 noticeId, category, title, content, createdAt


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-160]


## 👩‍💻 작업 내용
로그인, 로그아웃, 토큰 재발급 API를 구현했습니다.
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용
테스트 코드는 @MemberUuid 어노테이션을 수정할 예정이라, 그 때 같이 작성하겠습니다.
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->



[EDMT-160]: https://bbangbbangz.atlassian.net/browse/EDMT-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 로그인, 로그아웃, 토큰 재발급 API 엔드포인트가 추가되었습니다.
    - 로그인 및 토큰 재발급 시 accessToken과 refreshToken이 함께 반환됩니다.
    - 이메일과 비밀번호를 포함한 로그인 요청 데이터 검증이 강화되었습니다.

- **버그 수정**
    - 회원가입, 로그인 등에서 입력값의 공백 제거 방식이 개선되었습니다.

- **개선 및 변경**
    - 인증 관련 오류 코드가 세분화되어, 비밀번호 불일치 및 토큰 오류에 대한 안내가 명확해졌습니다.
    - 회원가입 시 응답 포맷이 일관성 있게 변경되었습니다.
    - 로그아웃 시 리프레시 토큰이 초기화되어 보안이 강화되었습니다.
    - 토큰 처리 로직이 개선되어 토큰 유효성 검증과 파싱이 명확해졌습니다.
    - 회원 조회 시 이메일 기반 조회 기능이 추가되었습니다.

- **테스트**
    - 일부 테스트 코드가 개선 및 정비되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->