### PR TITLE
[EDMT-173] @MemberUUID를 @MemberId로 변경하고, 바로 ID를 매핑하도록 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // Health Check
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -3,12 +3,15 @@
 === 회원 가입
 
 ==== 성공
+
 operation::auth/signup-success[snippets="http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 이미 가입한 회원
+
 operation::auth/signup-fail/duplicate-email[snippets="http-request,http-response"]
 
 ==== 실패: 유효하지 않은 비밀번호 형식
+
 include::{snippets}/auth/signup-fail/invalid-password-format/response-body.adoc[]
 include::{snippets}/auth/signup-fail/invalid-password-length/response-body.adoc[]
 include::{snippets}/auth/signup-fail/invalid-password-repetition/response-body.adoc[]
@@ -30,3 +33,27 @@ operation::auth/verify-email-fail/expired-code[snippets="query-parameters,http-r
 ==== 실패: 유효한 인증 코드가 존재하지 않음
 
 operation::auth/verify-email-fail/auth-code-not-found[snippets="query-parameters,http-request,http-response"]
+
+=== 로그인
+
+==== 성공
+
+operation::auth/login-success[snippets="http-request,request-fields,http-response,response-fields"]
+
+==== 실패: 비밀번호가 일치하지 않음
+operation::auth/login-fail/invalid-password[snippets="http-request,http-response"]
+
+==== 실패: 존재하지 않는 회원
+operation::auth/login-fail/member-not-found[snippets="http-request,http-response"]
+
+=== 로그아웃
+
+==== 성공
+
+operation::auth/logout-success[snippets="http-request,http-response"]
+
+=== 엑세스 토큰 재발급
+
+==== 성공
+
+operation::auth/reissue-success[snippets="http-request,http-response,response-fields"]

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -8,7 +8,7 @@ import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.common.ApiResponse;
-import com.edumate.eduserver.common.annotation.MemberUuid;
+import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -56,7 +56,7 @@ public class AuthController {
     }
 
     @PatchMapping("/logout")
-    public ApiResponse<Void> logout(@MemberUuid final String memberUuid) {
+    public ApiResponse<Void> logout(@MemberId final String memberUuid) {
         authFacade.logout(memberUuid.strip());
         return ApiResponse.success(CommonSuccessCode.OK);
     }

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -56,8 +56,8 @@ public class AuthController {
     }
 
     @PatchMapping("/logout")
-    public ApiResponse<Void> logout(@MemberId final String memberUuid) {
-        authFacade.logout(memberUuid.strip());
+    public ApiResponse<Void> logout(@MemberId final long memberId) {
+        authFacade.logout(memberId);
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 

--- a/src/main/java/com/edumate/eduserver/auth/exception/MismatchedPasswordException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/MismatchedPasswordException.java
@@ -1,11 +1,11 @@
 package com.edumate.eduserver.auth.exception;
 
-import com.edumate.eduserver.common.exception.BadRequestException;
-import com.edumate.eduserver.member.exception.code.MemberErrorCode;
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
+import com.edumate.eduserver.common.exception.UnauthorizedException;
 
-public class MismatchedPasswordException extends BadRequestException {
+public class MismatchedPasswordException extends UnauthorizedException {
 
-    public MismatchedPasswordException(final MemberErrorCode errorCode) {
+    public MismatchedPasswordException(final AuthErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -22,6 +22,7 @@ public enum AuthErrorCode implements ErrorCode {
     MISSED_TOKEN("EDMT-4010104", "인증 토큰이 누락되었습니다."),
     INVALID_TOKEN_TYPE("EDMT-4010105", "잘못된 유형의 토큰입니다. 요청에는 엑세스 토큰이 필요합니다."),
     INVALID_SIGNATURE_TOKEN("EDMT-4010106", "토큰의 서명이 유효하지 않습니다."),
+    INVALID_PASSWORD("EDMT-4010107", "비밀번호가 일치하지 않습니다."),
 
     // 403 Forbidden
     FORBIDDEN("EDMT-4030101", "권한이 부족한 사용자입니다."),

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -6,9 +6,6 @@ import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
-import com.edumate.eduserver.auth.security.jwt.JwtParser;
-import com.edumate.eduserver.auth.security.jwt.JwtValidator;
-import com.edumate.eduserver.auth.security.jwt.TokenType;
 import com.edumate.eduserver.auth.service.AuthService;
 import com.edumate.eduserver.auth.service.EmailService;
 import com.edumate.eduserver.auth.service.PasswordValidator;
@@ -35,8 +32,6 @@ public class AuthFacade {
     private final MemberService memberService;
     private final SubjectService subjectService;
     private final TokenService tokenService;
-    private final JwtValidator jwtValidator;
-    private final JwtParser jwtParser;
     private final PasswordEncoder passwordEncoder;
     private final RandomCodeGenerator randomCodeGenerator;
 
@@ -87,10 +82,8 @@ public class AuthFacade {
     }
 
     @Transactional
-    public MemberReissueResponse reissue(final String inputRefreshToken) {
-        String refreshToken = tokenService.getRemovedBearerPrefixToken(inputRefreshToken);
-        jwtValidator.validateToken(refreshToken, TokenType.REFRESH);
-        String memberUuid = jwtParser.getMemberUuidFromToken(refreshToken);
+    public MemberReissueResponse reissue(final String refreshToken) {
+        String memberUuid = tokenService.getMemberUuidFromToken(refreshToken);
         Member member = memberService.getMemberByUuid(memberUuid);
         Token token = tokenService.generateTokens(member);
         return MemberReissueResponse.of(token.accessToken(), token.refreshToken());

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -13,7 +13,6 @@ import com.edumate.eduserver.auth.service.RandomCodeGenerator;
 import com.edumate.eduserver.auth.service.Token;
 import com.edumate.eduserver.auth.service.TokenService;
 import com.edumate.eduserver.member.domain.Member;
-import com.edumate.eduserver.member.exception.code.MemberErrorCode;
 import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.subject.domain.Subject;
 import com.edumate.eduserver.subject.service.SubjectService;
@@ -69,7 +68,7 @@ public class AuthFacade {
     public MemberLoginResponse login(final String email, final String password) {
         Member member = memberService.getMemberByEmail(email);
         if (!passwordEncoder.matches(password, member.getPassword())) {
-            throw new MismatchedPasswordException(MemberErrorCode.MEMBER_NOT_FOUND);
+            throw new MismatchedPasswordException(AuthErrorCode.INVALID_PASSWORD);
         }
         Token token = tokenService.generateTokens(member);
         return MemberLoginResponse.of(token.accessToken(), token.refreshToken());

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -81,8 +81,8 @@ public class AuthFacade {
     }
 
     @Transactional
-    public void logout(final String memberUuid) {
-        Member member = memberService.getMemberByUuid(memberUuid);
+    public void logout(final long memberId) {
+        Member member = memberService.getMemberById(memberId);
         authService.logout(member);
     }
 

--- a/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtParser.java
+++ b/src/main/java/com/edumate/eduserver/auth/security/jwt/JwtParser.java
@@ -1,5 +1,7 @@
 package com.edumate.eduserver.auth.security.jwt;
 
+import com.edumate.eduserver.auth.exception.MissingTokenException;
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -14,12 +16,21 @@ public class JwtParser {
 
     private final JwtProperties jwtProperties;
 
+    private static final String BEARER = "Bearer ";
+
     public Claims parseClaims(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(getSigningKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public String resolveToken(final String token) {
+        if (token != null && token.startsWith(BEARER)) {
+            return token.substring(BEARER.length());
+        }
+        throw new MissingTokenException(AuthErrorCode.MISSED_TOKEN);
     }
 
     public String getMemberUuidFromToken(final String refreshToken) {

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -28,7 +28,7 @@ public class TokenService {
 
     public String getMemberUuidFromToken(final String refreshToken) {
         String prefixRemovedToken = jwtParser.resolveToken(refreshToken);
-        jwtValidator.validateToken(refreshToken, TokenType.REFRESH);
+        jwtValidator.validateToken(prefixRemovedToken, TokenType.REFRESH);
         return jwtParser.getMemberUuidFromToken(prefixRemovedToken);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -1,8 +1,8 @@
 package com.edumate.eduserver.auth.service;
 
-import com.edumate.eduserver.auth.exception.IllegalTokenException;
-import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
+import com.edumate.eduserver.auth.security.jwt.JwtParser;
+import com.edumate.eduserver.auth.security.jwt.JwtValidator;
 import com.edumate.eduserver.auth.security.jwt.TokenType;
 import com.edumate.eduserver.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TokenService {
 
     private final JwtGenerator jwtGenerator;
-
-    private static final String BEARER_PREFIX = "Bearer ";
+    private final JwtParser jwtParser;
+    private final JwtValidator jwtValidator;
 
     @Transactional
     public Token generateTokens(final Member member) {
@@ -26,10 +26,9 @@ public class TokenService {
         return Token.of(accessToken, refreshToken);
     }
 
-    public String getRemovedBearerPrefixToken(final String token) {
-        if (token != null && token.startsWith(BEARER_PREFIX)) {
-            return token.substring(BEARER_PREFIX.length());
-        }
-        throw new IllegalTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN_VALUE);
+    public String getMemberUuidFromToken(final String refreshToken) {
+        String prefixRemovedToken = jwtParser.resolveToken(refreshToken);
+        jwtValidator.validateToken(refreshToken, TokenType.REFRESH);
+        return jwtParser.getMemberUuidFromToken(prefixRemovedToken);
     }
 }

--- a/src/main/java/com/edumate/eduserver/common/MemberIdArgumentResolver.java
+++ b/src/main/java/com/edumate/eduserver/common/MemberIdArgumentResolver.java
@@ -14,9 +14,10 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        boolean hasMemberUuIdAnnotation = parameter.hasParameterAnnotation(MemberId.class);
-        boolean isLongType = parameter.getParameterType().equals(long.class);
-        return hasMemberUuIdAnnotation && isLongType;
+        boolean hasMemberIdAnnotation = parameter.hasParameterAnnotation(MemberId.class);
+        Class<?> type = parameter.getParameterType();
+        boolean isLongType = type.equals(long.class) || type.equals(Long.class);
+        return hasMemberIdAnnotation && isLongType;
     }
 
     @Override

--- a/src/main/java/com/edumate/eduserver/common/MemberIdArgumentResolver.java
+++ b/src/main/java/com/edumate/eduserver/common/MemberIdArgumentResolver.java
@@ -10,7 +10,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-public class MemberUuidArgumentResolver implements HandlerMethodArgumentResolver {
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {

--- a/src/main/java/com/edumate/eduserver/common/MemberUuidArgumentResolver.java
+++ b/src/main/java/com/edumate/eduserver/common/MemberUuidArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.edumate.eduserver.common;
 
-import com.edumate.eduserver.common.annotation.MemberUuid;
+import com.edumate.eduserver.common.annotation.MemberId;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -14,9 +14,9 @@ public class MemberUuidArgumentResolver implements HandlerMethodArgumentResolver
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        boolean hasMemberUuIdAnnotation = parameter.hasParameterAnnotation(MemberUuid.class);
-        boolean isStringType = parameter.getParameterType().equals(String.class);
-        return hasMemberUuIdAnnotation && isStringType;
+        boolean hasMemberUuIdAnnotation = parameter.hasParameterAnnotation(MemberId.class);
+        boolean isLongType = parameter.getParameterType().equals(Long.class);
+        return hasMemberUuIdAnnotation && isLongType;
     }
 
     @Override

--- a/src/main/java/com/edumate/eduserver/common/MemberUuidArgumentResolver.java
+++ b/src/main/java/com/edumate/eduserver/common/MemberUuidArgumentResolver.java
@@ -15,7 +15,7 @@ public class MemberUuidArgumentResolver implements HandlerMethodArgumentResolver
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
         boolean hasMemberUuIdAnnotation = parameter.hasParameterAnnotation(MemberId.class);
-        boolean isLongType = parameter.getParameterType().equals(Long.class);
+        boolean isLongType = parameter.getParameterType().equals(long.class);
         return hasMemberUuIdAnnotation && isLongType;
     }
 

--- a/src/main/java/com/edumate/eduserver/common/annotation/MemberId.java
+++ b/src/main/java/com/edumate/eduserver/common/annotation/MemberId.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface MemberUuid {
+public @interface MemberId {
 }

--- a/src/main/java/com/edumate/eduserver/common/config/WebConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/WebConfig.java
@@ -1,7 +1,7 @@
 package com.edumate.eduserver.common.config;
 
 import com.edumate.eduserver.common.StudentRecordTypeConverter;
-import com.edumate.eduserver.common.MemberUuidArgumentResolver;
+import com.edumate.eduserver.common.MemberIdArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final MemberUuidArgumentResolver memberUuIdArgumentResolver;
+    private final MemberIdArgumentResolver memberUuIdArgumentResolver;
     private final StudentRecordTypeConverter studentRecordTypeConverter;
 
     @Override

--- a/src/main/java/com/edumate/eduserver/common/security/MemberAuthentication.java
+++ b/src/main/java/com/edumate/eduserver/common/security/MemberAuthentication.java
@@ -11,7 +11,7 @@ public class MemberAuthentication extends UsernamePasswordAuthenticationToken {
         super(principal, credentials, authorities);
     }
 
-    public static MemberAuthentication create(final String memberUuid, final Collection<? extends GrantedAuthority> authorities) {
-        return new MemberAuthentication(memberUuid, null, authorities);
+    public static MemberAuthentication create(final long memberId, final Collection<? extends GrantedAuthority> authorities) {
+        return new MemberAuthentication(memberId, null, authorities);
     }
 }

--- a/src/main/java/com/edumate/eduserver/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/edumate/eduserver/common/security/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.edumate.eduserver.common.security.filter;
 
-import com.edumate.eduserver.auth.exception.MissingTokenException;
-import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.security.jwt.JwtParser;
 import com.edumate.eduserver.auth.security.jwt.JwtValidator;
 import com.edumate.eduserver.auth.security.jwt.TokenType;
@@ -22,8 +20,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final String BEARER = "Bearer ";
-
     private final MemberAuthenticationService memberAuthService;
     private final JwtValidator jwtValidator;
     private final JwtParser jwtParser;
@@ -31,7 +27,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
                                     final FilterChain filterChain) throws ServletException, IOException {
-        String token = resolveToken(request);
+        String requestedToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String token = jwtParser.resolveToken(requestedToken);
         jwtValidator.validateToken(token, TokenType.ACCESS);
         String memberUuid = jwtParser.parseClaims(token).getSubject();
         UserDetails userDetails = memberAuthService.loadUserByUsername(memberUuid);
@@ -40,13 +37,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
         filterChain.doFilter(request, response);
-    }
-
-    private String resolveToken(final HttpServletRequest request) {
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (token != null && token.startsWith(BEARER)) {
-            return token.substring(BEARER.length());
-        }
-        throw new MissingTokenException(AuthErrorCode.MISSED_TOKEN);
     }
 }

--- a/src/main/java/com/edumate/eduserver/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/edumate/eduserver/common/security/filter/JwtAuthenticationFilter.java
@@ -35,7 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         jwtValidator.validateToken(token, TokenType.ACCESS);
         String memberUuid = jwtParser.parseClaims(token).getSubject();
         UserDetails userDetails = memberAuthService.loadUserByUsername(memberUuid);
-        MemberAuthentication authentication = MemberAuthentication.create(memberUuid, userDetails.getAuthorities());
+        long memberId = Long.parseLong(userDetails.getUsername());
+        MemberAuthentication authentication = MemberAuthentication.create(memberId, userDetails.getAuthorities());
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
         filterChain.doFilter(request, response);

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -99,6 +99,10 @@ public class Member extends BaseEntity {
                 .build();
     }
 
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Role.toGrantedAuthorities(Set.of(role));
+    }
+
     public void verifyAsTeacher() {
         this.role = Role.TEACHER;
         this.verifiedAt = LocalDateTime.now();
@@ -106,10 +110,6 @@ public class Member extends BaseEntity {
 
     public void updateRefreshToken(final String refreshToken) {
         this.refreshToken = refreshToken;
-    }
-
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Role.toGrantedAuthorities(Set.of(role));
     }
 
     public void updateNickname(final String nickname) {

--- a/src/main/java/com/edumate/eduserver/member/service/MemberAuthenticationService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberAuthenticationService.java
@@ -21,7 +21,8 @@ public class MemberAuthenticationService implements UserDetailsService {
     public UserDetails loadUserByUsername(final String memberUuid) {
         try {
             Member member = getMemberByUuid(memberUuid);
-            return new User(member.getMemberUuid(), member.getPassword(), member.getAuthorities());
+            String memberId = String.valueOf(member.getId());
+            return new User(memberId, member.getPassword(), member.getAuthorities());
         } catch (MemberNotFoundException e) {
             throw new UsernameNotFoundException("Member not found with UUID: " + memberUuid, e);
         }

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -37,6 +37,11 @@ public class MemberService {
         return member.getMemberUuid();
     }
 
+    public Member getMemberById(final long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
     public Member getMemberByUuid(final String memberUuid) {
         return memberRepository.findByMemberUuid(memberUuid)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -1,7 +1,7 @@
 package com.edumate.eduserver.studentrecord.controller;
 
 import com.edumate.eduserver.common.ApiResponse;
-import com.edumate.eduserver.common.annotation.MemberUuid;
+import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordOverviewUpdateRequest;
@@ -34,21 +34,21 @@ public class StudentRecordController {
     private static final String DEFAULT_SEMESTER = "2025-1";
 
     @PostMapping("/detail/{recordId}")
-    public ApiResponse<Void> updateStudentRecord(@MemberUuid final String memberUuid, @PathVariable final long recordId,
+    public ApiResponse<Void> updateStudentRecord(@MemberId final String memberUuid, @PathVariable final long recordId,
                                                  @RequestBody @Valid final StudentRecordUpdateRequest request) {
         studentRecordFacade.updateStudentRecord(memberUuid.strip(), recordId, request.description().strip(), request.byteCount());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
     @GetMapping("/detail/{recordId}")
-    public ApiResponse<StudentRecordDetailResponse> getStudentRecord(@MemberUuid final String memberUuid,
+    public ApiResponse<StudentRecordDetailResponse> getStudentRecord(@MemberId final String memberUuid,
                                                                      @PathVariable final long recordId) {
         StudentRecordDetailResponse response = studentRecordFacade.getStudentRecord(memberUuid.strip(), recordId);
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 
     @GetMapping("/{recordType}")
-    public ApiResponse<StudentRecordOverviewsResponse> getStudentRecordOverviews(@MemberUuid final String memberUuid,
+    public ApiResponse<StudentRecordOverviewsResponse> getStudentRecordOverviews(@MemberId final String memberUuid,
                                                                                  @PathVariable final StudentRecordType recordType,
                                                                                  @RequestParam(defaultValue = DEFAULT_SEMESTER) final String semester) {
         StudentRecordOverviewsResponse response = studentRecordFacade.getStudentRecordOverviews(memberUuid.strip(), recordType, semester.strip());
@@ -56,7 +56,7 @@ public class StudentRecordController {
     }
 
     @GetMapping("/{recordType}/students")
-    public ApiResponse<StudentNamesResponse> getStudentDetails(@MemberUuid final String memberUuid,
+    public ApiResponse<StudentNamesResponse> getStudentDetails(@MemberId final String memberUuid,
                                                                @PathVariable final StudentRecordType recordType,
                                                                @RequestParam(defaultValue = DEFAULT_SEMESTER) final String semester) {
         StudentNamesResponse response = studentRecordFacade.getStudentDetails(memberUuid.strip(), recordType, semester.strip());
@@ -64,7 +64,7 @@ public class StudentRecordController {
     }
 
     @PostMapping("/{recordType}/students/batch")
-    public ApiResponse<Void> createStudentRecords(@MemberUuid final String memberUuid,
+    public ApiResponse<Void> createStudentRecords(@MemberId final String memberUuid,
                                                   @PathVariable final StudentRecordType recordType,
                                                   @RequestBody @Valid final StudentRecordsCreateRequest request) {
         studentRecordFacade.createStudentRecords(memberUuid.strip(), recordType, request.semester().strip(), request.studentRecords());
@@ -72,7 +72,7 @@ public class StudentRecordController {
     }
 
     @PostMapping("/{recordType}/students")
-    public ApiResponse<Void> createStudentRecord(@MemberUuid final String memberUuid,
+    public ApiResponse<Void> createStudentRecord(@MemberId final String memberUuid,
                                                  @PathVariable final StudentRecordType recordType,
                                                  @RequestBody @Valid final StudentRecordCreateRequest request) {
         studentRecordFacade.createStudentRecord(memberUuid.strip(), recordType, request.semester().trim(), request.studentRecord()); // 멤버 아이디 하드코딩
@@ -80,7 +80,7 @@ public class StudentRecordController {
     }
 
     @PatchMapping("/{recordId}")
-    public ApiResponse<Void> updateStudentRecordOverview(@MemberUuid final String memberUuid,
+    public ApiResponse<Void> updateStudentRecordOverview(@MemberId final String memberUuid,
                                                          @PathVariable final long recordId,
                                                          @RequestBody @Valid final StudentRecordOverviewUpdateRequest request) {
         studentRecordFacade.updateStudentRecordOverview(memberUuid.strip(), recordId, request.studentNumber(),
@@ -89,7 +89,7 @@ public class StudentRecordController {
     }
 
     @DeleteMapping("/{recordId}")
-    public ApiResponse<Void> deleteStudentRecord(@MemberUuid final String memberUuid,
+    public ApiResponse<Void> deleteStudentRecord(@MemberId final String memberUuid,
                                                  @PathVariable final long recordId) {
         studentRecordFacade.deleteStudentRecord(memberUuid.strip(), recordId);
         return ApiResponse.success(CommonSuccessCode.OK);

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -34,64 +34,67 @@ public class StudentRecordController {
     private static final String DEFAULT_SEMESTER = "2025-1";
 
     @PostMapping("/detail/{recordId}")
-    public ApiResponse<Void> updateStudentRecord(@MemberId final String memberUuid, @PathVariable final long recordId,
+    public ApiResponse<Void> updateStudentRecord(@MemberId final long memberId, @PathVariable final long recordId,
                                                  @RequestBody @Valid final StudentRecordUpdateRequest request) {
-        studentRecordFacade.updateStudentRecord(memberUuid.strip(), recordId, request.description().strip(), request.byteCount());
+        studentRecordFacade.updateStudentRecord(memberId, recordId, request.description().strip(), request.byteCount());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
     @GetMapping("/detail/{recordId}")
-    public ApiResponse<StudentRecordDetailResponse> getStudentRecord(@MemberId final String memberUuid,
+    public ApiResponse<StudentRecordDetailResponse> getStudentRecord(@MemberId final long memberId,
                                                                      @PathVariable final long recordId) {
-        StudentRecordDetailResponse response = studentRecordFacade.getStudentRecord(memberUuid.strip(), recordId);
+        StudentRecordDetailResponse response = studentRecordFacade.getStudentRecord(memberId, recordId);
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 
     @GetMapping("/{recordType}")
-    public ApiResponse<StudentRecordOverviewsResponse> getStudentRecordOverviews(@MemberId final String memberUuid,
+    public ApiResponse<StudentRecordOverviewsResponse> getStudentRecordOverviews(@MemberId final long memberId,
                                                                                  @PathVariable final StudentRecordType recordType,
                                                                                  @RequestParam(defaultValue = DEFAULT_SEMESTER) final String semester) {
-        StudentRecordOverviewsResponse response = studentRecordFacade.getStudentRecordOverviews(memberUuid.strip(), recordType, semester.strip());
+        StudentRecordOverviewsResponse response = studentRecordFacade.getStudentRecordOverviews(memberId, recordType,
+                semester.strip());
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 
     @GetMapping("/{recordType}/students")
-    public ApiResponse<StudentNamesResponse> getStudentDetails(@MemberId final String memberUuid,
+    public ApiResponse<StudentNamesResponse> getStudentDetails(@MemberId final long memberId,
                                                                @PathVariable final StudentRecordType recordType,
                                                                @RequestParam(defaultValue = DEFAULT_SEMESTER) final String semester) {
-        StudentNamesResponse response = studentRecordFacade.getStudentDetails(memberUuid.strip(), recordType, semester.strip());
+        StudentNamesResponse response = studentRecordFacade.getStudentDetails(memberId, recordType, semester.strip());
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 
     @PostMapping("/{recordType}/students/batch")
-    public ApiResponse<Void> createStudentRecords(@MemberId final String memberUuid,
+    public ApiResponse<Void> createStudentRecords(@MemberId final long memberId,
                                                   @PathVariable final StudentRecordType recordType,
                                                   @RequestBody @Valid final StudentRecordsCreateRequest request) {
-        studentRecordFacade.createStudentRecords(memberUuid.strip(), recordType, request.semester().strip(), request.studentRecords());
+        studentRecordFacade.createStudentRecords(memberId, recordType, request.semester().strip(),
+                request.studentRecords());
         return ApiResponse.success(CommonSuccessCode.CREATED);
     }
 
     @PostMapping("/{recordType}/students")
-    public ApiResponse<Void> createStudentRecord(@MemberId final String memberUuid,
+    public ApiResponse<Void> createStudentRecord(@MemberId final long memberId,
                                                  @PathVariable final StudentRecordType recordType,
                                                  @RequestBody @Valid final StudentRecordCreateRequest request) {
-        studentRecordFacade.createStudentRecord(memberUuid.strip(), recordType, request.semester().trim(), request.studentRecord()); // 멤버 아이디 하드코딩
+        studentRecordFacade.createStudentRecord(memberId, recordType, request.semester().strip(),
+                request.studentRecord());
         return ApiResponse.success(CommonSuccessCode.CREATED);
     }
 
     @PatchMapping("/{recordId}")
-    public ApiResponse<Void> updateStudentRecordOverview(@MemberId final String memberUuid,
+    public ApiResponse<Void> updateStudentRecordOverview(@MemberId final long memberId,
                                                          @PathVariable final long recordId,
                                                          @RequestBody @Valid final StudentRecordOverviewUpdateRequest request) {
-        studentRecordFacade.updateStudentRecordOverview(memberUuid.strip(), recordId, request.studentNumber(),
-                request.studentName(), request.description(), request.byteCount());
+        studentRecordFacade.updateStudentRecordOverview(memberId, recordId, request.studentNumber().strip(),
+                request.studentName().strip(), request.description().strip(), request.byteCount());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
     @DeleteMapping("/{recordId}")
-    public ApiResponse<Void> deleteStudentRecord(@MemberId final String memberUuid,
+    public ApiResponse<Void> deleteStudentRecord(@MemberId final long memberId,
                                                  @PathVariable final long recordId) {
-        studentRecordFacade.deleteStudentRecord(memberUuid.strip(), recordId);
+        studentRecordFacade.deleteStudentRecord(memberId, recordId);
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -1,7 +1,5 @@
 package com.edumate.eduserver.studentrecord.facade;
 
-import com.edumate.eduserver.member.domain.Member;
-import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
@@ -21,61 +19,53 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentRecordFacade {
 
     private final StudentRecordService studentRecordService;
-    private final MemberService memberService;
 
     @Transactional
-    public void updateStudentRecord(final String memberUuId, final long recordId, final String description,
+    public void updateStudentRecord(final long memberId, final long recordId, final String description,
                                     final int byteCount) {
-        Member member = memberService.getMemberByUuid(memberUuId);
-        studentRecordService.update(member.getId(), recordId, description, byteCount);
+        studentRecordService.update(memberId, recordId, description, byteCount);
     }
 
-    public StudentRecordDetailResponse getStudentRecord(final String memberUuid, final long recordId) {
-        Member member = memberService.getMemberByUuid(memberUuid);
-        StudentRecordDetail recordDetail = studentRecordService.getRecordDetail(member.getId(), recordId);
+    public StudentRecordDetailResponse getStudentRecord(final long memberId, final long recordId) {
+        StudentRecordDetail recordDetail = studentRecordService.getRecordDetail(memberId, recordId);
         return StudentRecordDetailResponse.of(recordDetail.getDescription(), recordDetail.getByteCount());
     }
 
-    public StudentRecordOverviewsResponse getStudentRecordOverviews(final String memberUuId,
+    public StudentRecordOverviewsResponse getStudentRecordOverviews(final long memberId,
                                                                     final StudentRecordType recordType,
                                                                     final String semester) {
-        Member member = memberService.getMemberByUuid(memberUuId);
-        List<StudentRecordDetail> recordOverview = studentRecordService.getAll(member.getId(), recordType, semester);
+        List<StudentRecordDetail> recordOverview = studentRecordService.getAll(memberId, recordType, semester);
         return StudentRecordOverviewsResponse.of(recordOverview);
     }
 
-    public StudentNamesResponse getStudentDetails(final String memberUuid, final StudentRecordType recordType,
+    public StudentNamesResponse getStudentDetails(final long memberId, final StudentRecordType recordType,
                                                   final String semester) {
-        Member member = memberService.getMemberByUuid(memberUuid);
-        List<StudentRecordDetail> studentRecordDetails = studentRecordService.getStudentNames(member.getId(), recordType, semester);
+        List<StudentRecordDetail> studentRecordDetails = studentRecordService.getStudentNames(memberId, recordType,
+                semester);
         return StudentNamesResponse.of(studentRecordDetails);
     }
 
     @Transactional
-    public void createStudentRecords(final String memberUuid, final StudentRecordType recordType, final String semester,
+    public void createStudentRecords(final long memberId, final StudentRecordType recordType, final String semester,
                                      final List<StudentRecordInfo> studentRecordInfos) {
-        Member member = memberService.getMemberByUuid(memberUuid);
-        studentRecordService.createStudentRecords(member.getId(), recordType, semester, studentRecordInfos);
+        studentRecordService.createStudentRecords(memberId, recordType, semester, studentRecordInfos);
     }
 
     @Transactional
-    public void createStudentRecord(final String memberUuid, final StudentRecordType recordType, final String semester,
+    public void createStudentRecord(final long memberId, final StudentRecordType recordType, final String semester,
                                     final StudentRecordCreateInfo studentRecordCreateInfo) {
-        Member member = memberService.getMemberByUuid(memberUuid);
-        studentRecordService.createStudentRecord(member.getId(), recordType, semester, studentRecordCreateInfo);
+        studentRecordService.createStudentRecord(memberId, recordType, semester, studentRecordCreateInfo);
     }
 
     @Transactional
-    public void updateStudentRecordOverview(final String memberUuid, final long recordId, final String studentNumber,
+    public void updateStudentRecordOverview(final long memberId, final long recordId, final String studentNumber,
                                             final String studentName, final String description, final int byteCount) {
-        Member member = memberService.getMemberByUuid(memberUuid);
-        studentRecordService.updateStudentRecordOverview(member.getId(), recordId, studentNumber, studentName,
+        studentRecordService.updateStudentRecordOverview(memberId, recordId, studentNumber, studentName,
                 description, byteCount);
     }
 
     @Transactional
-    public void deleteStudentRecord(final String memberUuid, final long recordId) {
-        Member member = memberService.getMemberByUuid(memberUuid);
-        studentRecordService.deleteStudentRecord(member.getId(), recordId);
+    public void deleteStudentRecord(final long memberId, final long recordId) {
+        studentRecordService.deleteStudentRecord(memberId, recordId);
     }
 }

--- a/src/test/java/com/edumate/eduserver/auth/facade/AuthFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/facade/AuthFacadeTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.verify;
 import com.edumate.eduserver.auth.exception.InvalidPasswordFormatException;
 import com.edumate.eduserver.auth.exception.InvalidPasswordLengthException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
-import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
 import com.edumate.eduserver.auth.service.AuthService;
 import com.edumate.eduserver.auth.service.EmailService;
 import com.edumate.eduserver.auth.service.RandomCodeGenerator;
@@ -38,8 +37,6 @@ class AuthFacadeTest {
     SubjectService subjectService;
     @Mock
     TokenService tokenService;
-    @Mock
-    JwtGenerator jwtGenerator;
     @Mock
     PasswordEncoder passwordEncoder;
     @Mock

--- a/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
@@ -1,0 +1,80 @@
+package com.edumate.eduserver.auth.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
+import com.edumate.eduserver.auth.security.jwt.JwtParser;
+import com.edumate.eduserver.auth.security.jwt.JwtValidator;
+import com.edumate.eduserver.auth.security.jwt.TokenType;
+import com.edumate.eduserver.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class TokenServiceTest {
+
+    @Mock
+    private JwtGenerator jwtGenerator;
+    @Mock
+    private JwtParser jwtParser;
+    @Mock
+    private JwtValidator jwtValidator;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("토큰이 정상적으로 생성된다.")
+    void generateTokens_success() {
+        Member member = mock(Member.class);
+        when(member.getMemberUuid()).thenReturn("uuid-1234");
+        when(jwtGenerator.generateToken("uuid-1234", TokenType.ACCESS)).thenReturn("access-token");
+        when(jwtGenerator.generateToken("uuid-1234", TokenType.REFRESH)).thenReturn("refresh-token");
+
+        Token token = tokenService.generateTokens(member);
+
+        verify(member).updateRefreshToken("refresh-token");
+        assertThat(token.accessToken()).isEqualTo("access-token");
+        assertThat(token.refreshToken()).isEqualTo("refresh-token");
+    }
+
+    @Test
+    @DisplayName("refreshToken에서 memberUuid를 정상적으로 추출한다.")
+    void getMemberUuidFromToken_success() {
+        String refreshToken = "Bearer refresh-token";
+        String resolvedToken = "refresh-token";
+        when(jwtParser.resolveToken(refreshToken)).thenReturn(resolvedToken);
+        doNothing().when(jwtValidator).validateToken(resolvedToken, TokenType.REFRESH);
+        when(jwtParser.getMemberUuidFromToken(resolvedToken)).thenReturn("uuid-1234");
+
+        String uuid = tokenService.getMemberUuidFromToken(refreshToken);
+        assertThat(uuid).isEqualTo("uuid-1234");
+    }
+
+    @Test
+    @DisplayName("refreshToken이 유효하지 않으면 예외가 발생한다.")
+    void getMemberUuidFromToken_invalidToken() {
+        String refreshToken = "Bearer invalid-token";
+        String resolvedToken = "invalid-token";
+        when(jwtParser.resolveToken(refreshToken)).thenReturn(resolvedToken);
+        doThrow(new IllegalArgumentException("유효하지 않은 토큰입니다.")).when(jwtValidator).validateToken(resolvedToken, TokenType.REFRESH);
+
+        assertThrows(IllegalArgumentException.class, () -> tokenService.getMemberUuidFromToken(refreshToken));
+    }
+}
+

--- a/src/test/java/com/edumate/eduserver/config/TestSecurityConfig.java
+++ b/src/test/java/com/edumate/eduserver/config/TestSecurityConfig.java
@@ -12,7 +12,8 @@ public class TestSecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .formLogin(AbstractHttpConfigurer::disable);
         return http.build();
     }
 }

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -26,7 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.edumate.eduserver.common.MemberIdArgumentResolver;
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordOverviewUpdateRequest;
@@ -48,12 +47,10 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DisplayName("학생 생활기록부 컨트롤러 테스트")
-@Import(MemberIdArgumentResolver.class)
 @WebMvcTest(StudentRecordController.class)
 class StudentRecordControllerTest extends ControllerTest {
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
@@ -44,12 +43,9 @@ class StudentRecordFacadeTest {
         long recordId = 1L;
         String description = "안녕하세요";
         int byteCount = 10;
-        Member member = mock(Member.class);
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(100L);
-        willDoNothing().given(studentRecordService).update(100L, recordId, description, byteCount);
+        willDoNothing().given(studentRecordService).update(memberId, recordId, description, byteCount);
         studentRecordFacade.updateStudentRecord(memberId, recordId, description, byteCount);
-        verify(studentRecordService).update(100L, recordId, description, byteCount);
+        verify(studentRecordService).update(memberId, recordId, description, byteCount);
     }
 
     @Test
@@ -57,14 +53,13 @@ class StudentRecordFacadeTest {
     void getStudentRecord() {
         long memberId = 200L;
         long recordId = 2L;
-        Member member = mock(Member.class);
         StudentRecordDetail detail = mock(StudentRecordDetail.class);
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(200L);
-        given(studentRecordService.getRecordDetail(200L, recordId)).willReturn(detail);
+        given(studentRecordService.getRecordDetail(memberId, recordId)).willReturn(detail);
         given(detail.getDescription()).willReturn("desc");
         given(detail.getByteCount()).willReturn(20);
+
         StudentRecordDetailResponse response = studentRecordFacade.getStudentRecord(memberId, recordId);
+
         assertThat(response.description()).isEqualTo("desc");
         assertThat(response.byteCount()).isEqualTo(20);
     }
@@ -75,13 +70,12 @@ class StudentRecordFacadeTest {
         long memberId = 300L;
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-1";
-        Member member = mock(Member.class);
         List<StudentRecordDetail> details = List.of(mock(StudentRecordDetail.class));
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(300L);
-        given(studentRecordService.getAll(300L, type, semester)).willReturn(details);
+        given(studentRecordService.getAll(memberId, type, semester)).willReturn(details);
+
         StudentRecordOverviewsResponse response = studentRecordFacade.getStudentRecordOverviews(memberId, type,
                 semester);
+
         assertThat(response).isNotNull();
     }
 
@@ -91,12 +85,11 @@ class StudentRecordFacadeTest {
         long memberId = 400L;
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-2";
-        Member member = mock(Member.class);
         List<StudentRecordDetail> details = List.of(mock(StudentRecordDetail.class));
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(400L);
-        given(studentRecordService.getStudentNames(400L, type, semester)).willReturn(details);
+        given(studentRecordService.getStudentNames(memberId, type, semester)).willReturn(details);
+
         StudentNamesResponse response = studentRecordFacade.getStudentDetails(memberId, type, semester);
+
         assertThat(response).isNotNull();
     }
 
@@ -107,12 +100,11 @@ class StudentRecordFacadeTest {
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-2";
         List<StudentRecordInfo> infos = List.of(mock(StudentRecordInfo.class));
-        Member member = mock(Member.class);
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(500L);
-        willDoNothing().given(studentRecordService).createStudentRecords(500L, type, semester, infos);
+        willDoNothing().given(studentRecordService).createStudentRecords(memberId, type, semester, infos);
+
         studentRecordFacade.createStudentRecords(memberId, type, semester, infos);
-        verify(studentRecordService).createStudentRecords(500L, type, semester, infos);
+
+        verify(studentRecordService).createStudentRecords(memberId, type, semester, infos);
     }
 
     @Test
@@ -122,11 +114,10 @@ class StudentRecordFacadeTest {
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-2";
         StudentRecordCreateInfo info = mock(StudentRecordCreateInfo.class);
-        Member member = mock(Member.class);
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(500L);
+
         studentRecordFacade.createStudentRecord(memberId, type, semester, info);
-        verify(studentRecordService).createStudentRecord(500L, type, semester, info);
+
+        verify(studentRecordService).createStudentRecord(memberId, type, semester, info);
     }
 
     @Test
@@ -138,14 +129,15 @@ class StudentRecordFacadeTest {
         String studentName = "김철수";
         String description = "리더십을 발휘하여 팀 프로젝트를 성공적으로 완수함.";
         int byteCount = 120;
-        Member member = mock(Member.class);
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(200L);
+
         willDoNothing().given(studentRecordService)
-                .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
-        studentRecordFacade.updateStudentRecordOverview(memberId, recordId, studentNumber, studentName, description, byteCount);
+                .updateStudentRecordOverview(memberId, recordId, studentNumber, studentName, description, byteCount);
+
+        studentRecordFacade.updateStudentRecordOverview(memberId, recordId, studentNumber, studentName, description,
+                byteCount);
+
         verify(studentRecordService)
-                .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
+                .updateStudentRecordOverview(memberId, recordId, studentNumber, studentName, description, byteCount);
     }
 
     @Test
@@ -153,12 +145,12 @@ class StudentRecordFacadeTest {
     void deleteStudentRecordFacade() {
         long memberId = 300L;
         long recordId = 3L;
-        Member member = mock(Member.class);
-        given(memberService.getMemberById(memberId)).willReturn(member);
-        given(member.getId()).willReturn(300L);
-        willDoNothing().given(studentRecordService).deleteStudentRecord(300L, recordId);
+
+        willDoNothing().given(studentRecordService).deleteStudentRecord(memberId, recordId);
+
         studentRecordFacade.deleteStudentRecord(memberId, recordId);
-        verify(studentRecordService).deleteStudentRecord(300L, recordId);
+
+        verify(studentRecordService).deleteStudentRecord(memberId, recordId);
     }
 }
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -40,31 +40,31 @@ class StudentRecordFacadeTest {
     @Test
     @DisplayName("학생 기록 수정이 정상 동작한다.")
     void updateStudentRecord() {
-        String memberUuid = "uuid-1";
+        long memberId = 100L;
         long recordId = 1L;
         String description = "안녕하세요";
         int byteCount = 10;
         Member member = mock(Member.class);
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(100L);
         willDoNothing().given(studentRecordService).update(100L, recordId, description, byteCount);
-        studentRecordFacade.updateStudentRecord(memberUuid, recordId, description, byteCount);
+        studentRecordFacade.updateStudentRecord(memberId, recordId, description, byteCount);
         verify(studentRecordService).update(100L, recordId, description, byteCount);
     }
 
     @Test
     @DisplayName("학생 기록 상세 조회가 정상 동작한다.")
     void getStudentRecord() {
-        String memberUuid = "uuid-2";
+        long memberId = 200L;
         long recordId = 2L;
         Member member = mock(Member.class);
         StudentRecordDetail detail = mock(StudentRecordDetail.class);
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(200L);
         given(studentRecordService.getRecordDetail(200L, recordId)).willReturn(detail);
         given(detail.getDescription()).willReturn("desc");
         given(detail.getByteCount()).willReturn(20);
-        StudentRecordDetailResponse response = studentRecordFacade.getStudentRecord(memberUuid, recordId);
+        StudentRecordDetailResponse response = studentRecordFacade.getStudentRecord(memberId, recordId);
         assertThat(response.description()).isEqualTo("desc");
         assertThat(response.byteCount()).isEqualTo(20);
     }
@@ -72,15 +72,15 @@ class StudentRecordFacadeTest {
     @Test
     @DisplayName("학생 기록 오버뷰 조회가 정상 동작한다.")
     void getStudentRecordOverviews() {
-        String memberUuid = "uuid-3";
+        long memberId = 300L;
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-1";
         Member member = mock(Member.class);
         List<StudentRecordDetail> details = List.of(mock(StudentRecordDetail.class));
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(300L);
         given(studentRecordService.getAll(300L, type, semester)).willReturn(details);
-        StudentRecordOverviewsResponse response = studentRecordFacade.getStudentRecordOverviews(memberUuid, type,
+        StudentRecordOverviewsResponse response = studentRecordFacade.getStudentRecordOverviews(memberId, type,
                 semester);
         assertThat(response).isNotNull();
     }
@@ -88,62 +88,62 @@ class StudentRecordFacadeTest {
     @Test
     @DisplayName("학생 이름 목록 조회가 정상 동작한다.")
     void getStudentDetails() {
-        String memberUuid = "uuid-4";
+        long memberId = 400L;
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-2";
         Member member = mock(Member.class);
         List<StudentRecordDetail> details = List.of(mock(StudentRecordDetail.class));
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(400L);
         given(studentRecordService.getStudentNames(400L, type, semester)).willReturn(details);
-        StudentNamesResponse response = studentRecordFacade.getStudentDetails(memberUuid, type, semester);
+        StudentNamesResponse response = studentRecordFacade.getStudentDetails(memberId, type, semester);
         assertThat(response).isNotNull();
     }
 
     @Test
     @DisplayName("학생 기록 생성이 정상 동작한다.")
     void createStudentRecords() {
-        String memberUuid = "uuid-5";
+        long memberId = 500L;
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-2";
         List<StudentRecordInfo> infos = List.of(mock(StudentRecordInfo.class));
         Member member = mock(Member.class);
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(500L);
         willDoNothing().given(studentRecordService).createStudentRecords(500L, type, semester, infos);
-        studentRecordFacade.createStudentRecords(memberUuid, type, semester, infos);
+        studentRecordFacade.createStudentRecords(memberId, type, semester, infos);
         verify(studentRecordService).createStudentRecords(500L, type, semester, infos);
     }
 
     @Test
     @DisplayName("학생 기록 생성이 정상 동작한다.")
     void createStudentRecord() {
-        String memberUuid = "uuid-5";
+        long memberId = 500L;
         StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
         String semester = "2024-2";
         StudentRecordCreateInfo info = mock(StudentRecordCreateInfo.class);
         Member member = mock(Member.class);
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(500L);
-        studentRecordFacade.createStudentRecord(memberUuid, type, semester, info);
+        studentRecordFacade.createStudentRecord(memberId, type, semester, info);
         verify(studentRecordService).createStudentRecord(500L, type, semester, info);
     }
 
     @Test
     @DisplayName("생활기록부 전체 수정이 정상 동작한다.")
     void updateStudentRecordOverview() {
-        String memberUuid = "uuid-2";
+        long memberId = 200L;
         long recordId = 2L;
         String studentNumber = "20204567";
         String studentName = "김철수";
         String description = "리더십을 발휘하여 팀 프로젝트를 성공적으로 완수함.";
         int byteCount = 120;
         Member member = mock(Member.class);
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(200L);
         willDoNothing().given(studentRecordService)
                 .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
-        studentRecordFacade.updateStudentRecordOverview(memberUuid, recordId, studentNumber, studentName, description, byteCount);
+        studentRecordFacade.updateStudentRecordOverview(memberId, recordId, studentNumber, studentName, description, byteCount);
         verify(studentRecordService)
                 .updateStudentRecordOverview(200L, recordId, studentNumber, studentName, description, byteCount);
     }
@@ -151,13 +151,13 @@ class StudentRecordFacadeTest {
     @Test
     @DisplayName("생활기록부 삭제가 정상 동작한다.")
     void deleteStudentRecordFacade() {
-        String memberUuid = "uuid-3";
+        long memberId = 300L;
         long recordId = 3L;
         Member member = mock(Member.class);
-        given(memberService.getMemberByUuid(memberUuid)).willReturn(member);
+        given(memberService.getMemberById(memberId)).willReturn(member);
         given(member.getId()).willReturn(300L);
         willDoNothing().given(studentRecordService).deleteStudentRecord(300L, recordId);
-        studentRecordFacade.deleteStudentRecord(memberUuid, recordId);
+        studentRecordFacade.deleteStudentRecord(memberId, recordId);
         verify(studentRecordService).deleteStudentRecord(300L, recordId);
     }
 }

--- a/src/test/java/com/edumate/eduserver/util/ControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/util/ControllerTest.java
@@ -4,6 +4,7 @@ import com.edumate.eduserver.common.security.MemberAuthentication;
 import com.edumate.eduserver.config.TestSecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -33,6 +34,11 @@ public class ControllerTest {
         List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
         MemberAuthentication authentication = MemberAuthentication.create(memberId, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     protected String toJson(Object obj) throws Exception {

--- a/src/test/java/com/edumate/eduserver/util/ControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/util/ControllerTest.java
@@ -1,11 +1,17 @@
 package com.edumate.eduserver.util;
 
+import com.edumate.eduserver.common.security.MemberAuthentication;
 import com.edumate.eduserver.config.TestSecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -21,11 +27,15 @@ public class ControllerTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
-    protected String toJson(Object obj) throws Exception {
-        return objectMapper.writeValueAsString(obj);
+    @BeforeEach
+    void setUp() {
+        long memberId = 10L;
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        MemberAuthentication authentication = MemberAuthentication.create(memberId, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    protected <T> T fromJson(String json, Class<T> clazz) throws Exception {
-        return objectMapper.readValue(json, clazz);
+    protected String toJson(Object obj) throws Exception {
+        return objectMapper.writeValueAsString(obj);
     }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-173]


## 👩‍💻 작업 내용
@MemberId 어노테이션을 통해 바로 memberID 값으로 매핑되도록 코드를 수정하였습니다.
테스트는 일단 SpringContext에 유저 정보를 하드코딩하는 방식으로 해결했습니다. 후에 테스트 코드는 다시 공부하면서 전체적으로 고쳐야할 것 같아요.
<!-- 작업 내용을 적어주세요 -->



[EDMT-173]: https://bbangbbangz.atlassian.net/browse/EDMT-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 인증 API 문서에 로그인, 로그아웃, 토큰 재발급 관련 항목이 추가되었습니다.
    - Spring Security 테스트 유틸리티가 테스트 환경에 도입되었습니다.

- **버그 수정**
    - 비밀번호 불일치 시 반환되는 에러 코드 및 예외 처리가 보다 명확하게 개선되었습니다.

- **리팩터**
    - 회원 식별 방식이 UUID(String)에서 ID(long)로 일괄 변경되어 API 파라미터, 컨트롤러, 서비스, 테스트 코드가 모두 일관성 있게 수정되었습니다.
    - 토큰 파싱 및 검증 로직이 분리되어 유지보수가 용이해졌습니다.

- **문서**
    - 인증 및 학생부 관련 API 문서가 확장 및 개선되었습니다.

- **테스트**
    - 인증 및 학생부 관련 컨트롤러 테스트가 추가 및 보강되었습니다.
    - 테스트 환경에서 보안 설정이 명확하게 적용되었습니다.
    - 토큰 서비스 관련 단위 테스트가 새로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->