### PR TITLE
[EDMT-186] 교사 인증 이메일 전송 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    // Spring AI
+    implementation "org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.1"
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
-    // Spring AI
-    implementation "org.springframework.ai:spring-ai-openai-spring-boot-starter:0.8.1"
-
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -16,6 +16,12 @@ include::{snippets}/auth/signup-fail/invalid-password-format/response-body.adoc[
 include::{snippets}/auth/signup-fail/invalid-password-length/response-body.adoc[]
 include::{snippets}/auth/signup-fail/invalid-password-repetition/response-body.adoc[]
 
+=== 교사 인증을 위한 이메일 전송
+
+==== 성공
+
+operation::auth/send-email-success[snippets="http-request,request-headers,http-response,response-fields"]
+
 === 이메일 인증 코드 인증
 
 ==== 성공
@@ -41,19 +47,21 @@ operation::auth/verify-email-fail/auth-code-not-found[snippets="query-parameters
 operation::auth/login-success[snippets="http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 비밀번호가 일치하지 않음
+
 operation::auth/login-fail/invalid-password[snippets="http-request,http-response"]
 
 ==== 실패: 존재하지 않는 회원
+
 operation::auth/login-fail/member-not-found[snippets="http-request,http-response"]
 
 === 로그아웃
 
 ==== 성공
 
-operation::auth/logout-success[snippets="http-request,http-response"]
+operation::auth/logout-success[snippets="http-request,request-headers,http-response"]
 
 === 엑세스 토큰 재발급
 
 ==== 성공
 
-operation::auth/reissue-success[snippets="http-request,http-response,response-fields"]
+operation::auth/reissue-success[snippets="http-request,request-headers,http-response,response-fields"]

--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -4,7 +4,7 @@
 
 ==== 성공
 
-operation::student-record/update-success[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+operation::student-record/update-success[snippets="request-headers,path-parameters,http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 해당 학기에 해당 유저의 존재하지 않는 생기부
 
@@ -15,6 +15,7 @@ operation::student-record/fail/member-record-not-found[snippets="http-request,ht
 operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
 
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
+
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]
 
 ==== 실패: 유효하지 않은 요청 값
@@ -26,7 +27,7 @@ include::{snippets}/student-record/update-fail/negative-byte-count/http-response
 
 ==== 성공
 
-operation::student-record/get-success[snippets="path-parameters,http-request,http-response"]
+operation::student-record/get-success[snippets="request-headers,path-parameters,http-request,http-response"]
 
 ==== 실패: 해당 학기에 해당 유저의 존재하지 않는 생기부
 
@@ -37,13 +38,14 @@ operation::student-record/fail/member-record-not-found[snippets="http-response"]
 operation::student-record/fail/record-not-found[snippets="http-response"]
 
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
+
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]
 
 === 학생 이름 불러오기
 
 ==== 성공
 
-operation::student-record/get-names-success[snippets="path-parameters,query-parameters,http-request,http-response"]
+operation::student-record/get-names-success[snippets="request-headers,path-parameters,query-parameters,http-request,http-response"]
 
 ==== 실패: 해당 학기에 해당 유저의 존재하지 않는 생기부
 
@@ -57,19 +59,21 @@ operation::student-record/get-names-fail/invalid-semester-format[snippets=http-r
 
 ==== 성공
 
-operation::student-record/create-success[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+operation::student-record/create-success[snippets="request-headers,path-parameters,http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 해당 학기에 해당 유저의 존재하지 않는 생기부
+
 operation::student-record/fail/member-record-not-found[snippets="http-response"]
 
 ==== 실패: 유효하지 않은 학기 형식
+
 operation::student-record/get-names-fail/invalid-semester-format[snippets=http-response]
 
 === 생활기록부 한 명 추가
 
 ==== 성공
 
-operation::student-record/create-one-success[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+operation::student-record/create-one-success[snippets="request-headers,path-parameters,http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 유효하지 않은 학기 형식
 
@@ -79,24 +83,26 @@ operation::student-record/get-names-fail/invalid-semester-format[snippets=http-r
 
 ==== 성공
 
-operation::student-record/update-overview-success[snippets="path-parameters,http-request,request-fields,http-response,response-fields"]
+operation::student-record/update-overview-success[snippets="request-headers,path-parameters,http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 특정 학생의 생기부가 존재하지 않음
 
 operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
 
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
+
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]
 
 === 생활기록부 한 명 삭제
 
 ==== 성공
 
-operation::student-record/delete-success[snippets="path-parameters,http-request,http-response,response-fields"]
+operation::student-record/delete-success[snippets="request-headers,path-parameters,http-request,http-response,response-fields"]
 
 ==== 실패: 특정 학생의 생기부가 존재하지 않음
 
 operation::student-record/fail/record-not-found[snippets="http-request,http-response"]
 
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
+
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.edumate.eduserver.auth.controller;
 
-import com.edumate.eduserver.auth.controller.request.EmailSendRequest;
 import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
 import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
 import com.edumate.eduserver.auth.facade.AuthFacade;
@@ -30,8 +29,8 @@ public class AuthController {
     private final AuthFacade authFacade;
 
     @PostMapping("/email/send-verification")
-    public ApiResponse<Void> sendVerificationEmail(@RequestBody @Valid final EmailSendRequest request) {
-        authFacade.sendVerificationEmail(request.memberUuid().strip());
+    public ApiResponse<Void> sendVerificationEmail(@MemberId final long memberId) {
+        authFacade.sendVerificationEmail(memberId);
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 

--- a/src/main/java/com/edumate/eduserver/auth/controller/request/EmailSendRequest.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/request/EmailSendRequest.java
@@ -1,9 +1,0 @@
-package com.edumate.eduserver.auth.controller.request;
-
-import jakarta.validation.constraints.NotNull;
-
-public record EmailSendRequest(
-        @NotNull(message = "회원 UUID는 필수입니다.")
-        String memberUuid
-) {
-}

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -34,11 +34,11 @@ public class AuthFacade {
     private final PasswordEncoder passwordEncoder;
     private final RandomCodeGenerator randomCodeGenerator;
 
-    public void sendVerificationEmail(final String memberUuid) {
-        Member member = memberService.getMemberByUuid(memberUuid);
+    public void sendVerificationEmail(final long memberId) {
+        Member member = memberService.getMemberById(memberId);
         String verificationCode = randomCodeGenerator.generate();
         authService.saveCode(member, verificationCode);
-        emailService.sendEmail(member.getEmail(), memberUuid, verificationCode);
+        emailService.sendEmail(member.getEmail(), member.getMemberUuid(), verificationCode);
     }
 
     @Transactional

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -480,5 +481,6 @@ class AuthControllerTest extends ControllerTest {
                                 fieldWithPath("message").description("응답 메시지")
                         )
                 ));
+        verify(authFacade).sendVerificationEmail(anyLong());
     }
 }

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -1,10 +1,12 @@
 package com.edumate.eduserver.auth.controller;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -14,8 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
 import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
+import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
 import com.edumate.eduserver.auth.exception.AuthCodeNotFoundException;
 import com.edumate.eduserver.auth.exception.ExpiredCodeException;
 import com.edumate.eduserver.auth.exception.MemberAlreadyRegisteredException;
@@ -23,9 +25,9 @@ import com.edumate.eduserver.auth.exception.MisMatchedCodeException;
 import com.edumate.eduserver.auth.exception.MismatchedPasswordException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.facade.AuthFacade;
-import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
+import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
 import com.edumate.eduserver.member.exception.MemberNotFoundException;
 import com.edumate.eduserver.member.exception.code.MemberErrorCode;
@@ -416,6 +418,9 @@ class AuthControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "logout-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("인증된 액세스 토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("응답 코드"),
@@ -440,6 +445,9 @@ class AuthControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
                 .andExpect(jsonPath("$.data.refreshToken").value("new-refresh-token"))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "reissue-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("리프레시 토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("응답 코드"),
@@ -463,6 +471,9 @@ class AuthControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "send-email-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         responseFields(
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("응답 코드"),

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.edumate.eduserver.auth.controller;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -201,10 +202,10 @@ class AuthControllerTest extends ControllerTest {
                 "duplicate@email.com", "password123", "수학", "middle");
         doThrow(new MemberAlreadyRegisteredException(AuthErrorCode.MEMBER_ALREADY_REGISTERED))
                 .when(authFacade).signUp(
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString()
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString()
                 );
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/signup")
@@ -231,10 +232,10 @@ class AuthControllerTest extends ControllerTest {
         doThrow(new com.edumate.eduserver.auth.exception.InvalidPasswordLengthException(
                 AuthErrorCode.INVALID_PASSWORD_LENGTH))
                 .when(authFacade).signUp(
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString()
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString()
                 );
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/signup")
@@ -261,10 +262,10 @@ class AuthControllerTest extends ControllerTest {
         doThrow(new com.edumate.eduserver.auth.exception.InvalidPasswordFormatException(
                 AuthErrorCode.INVALID_PASSWORD_FORMAT))
                 .when(authFacade).signUp(
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString()
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString()
                 );
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/signup")
@@ -291,10 +292,10 @@ class AuthControllerTest extends ControllerTest {
         doThrow(new com.edumate.eduserver.auth.exception.InvalidPasswordFormatException(
                 AuthErrorCode.INVALID_PASSWORD_FORMAT))
                 .when(authFacade).signUp(
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString()
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString()
                 );
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/signup")
@@ -405,7 +406,7 @@ class AuthControllerTest extends ControllerTest {
     @Test
     @DisplayName("로그아웃에 성공한다.")
     void logoutSuccess() throws Exception {
-        doNothing().when(authFacade).logout(org.mockito.ArgumentMatchers.anyLong());
+        doNothing().when(authFacade).logout(anyLong());
 
         mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/logout")
                         .header("Authorization", "Bearer access-token"))
@@ -427,7 +428,7 @@ class AuthControllerTest extends ControllerTest {
     @DisplayName("토큰 재발급에 성공한다.")
     void reissueSuccess() throws Exception {
         MemberReissueResponse response = new MemberReissueResponse("new-access-token", "new-refresh-token");
-        when(authFacade.reissue(org.mockito.ArgumentMatchers.anyString())).thenReturn(response);
+        when(authFacade.reissue(anyString())).thenReturn(response);
 
         mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/reissue")
                         .header("Authorization", "Bearer refresh-token"))
@@ -445,6 +446,27 @@ class AuthControllerTest extends ControllerTest {
                                 fieldWithPath("message").description("응답 메시지"),
                                 fieldWithPath("data.accessToken").description("새로운 액세스 토큰"),
                                 fieldWithPath("data.refreshToken").description("새로운 리프레시 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 메일 전송에 성공한다.")
+    void sendVerificationEmailSuccess() throws Exception {
+        doNothing().when(authFacade).sendVerificationEmail(anyLong());
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/email/send-verification")
+                        .header("Authorization", "Bearer access-token"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "send-email-success",
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
                         )
                 ));
     }

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -12,6 +12,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
@@ -83,6 +85,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생의 생기부 레코드 ID")
                         ),
@@ -117,6 +122,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "get-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생 레코드 ID")
                         ),
@@ -131,7 +139,7 @@ class StudentRecordControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("특정 학기 특정 생활기록부 항목에 작성된 학생 정�� 목록을 성공적으로 불러온다.")
+    @DisplayName("특정 학기 특정 생활기록부 항목에 작성된 학생 정보 목록을 성공적으로 불러온다.")
     void getStudentName() throws Exception {
         // given
         StudentDetail detail1 = new StudentDetail(1L, "김가연");
@@ -151,6 +159,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "get-names-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordType").description("생활기록부 항목 타입")
                         ),
@@ -188,6 +199,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-201"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "create-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordType").description("생활기록부 항목 타입")
                         ),
@@ -228,6 +242,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.message").value(
                         STUDENT_RECORD_DETAIL_NOT_FOUND.getMessage()))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "fail/record-not-found",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생의 생기부 레코드 ID")
                         ),
@@ -266,6 +283,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.message").value(
                         MEMBER_STUDENT_RECORD_NOT_FOUND.getMessage()))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "fail/member-record-not-found",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생의 생기부 레코드 ID")
                         ),
@@ -299,6 +319,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-4002"))
                 .andExpect(jsonPath("$.message").value("null 값은 허용되지 않습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-fail/missing-description",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생의 생기부 레코드 ID")
                         ),
@@ -332,6 +355,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-4002"))
                 .andExpect(jsonPath("$.message").value("바이트 수는 0 이상이어야 합니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-fail/negative-byte-count",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생의 생기부 레코드 ID")
                         ),
@@ -368,6 +394,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.message").value(
                         String.format("입력하신 %s는 유효하지 않은 학기 형식입니다. 올바른 형식은 'YYYY-1' 또는 'YYYY-2'입니다.", invalidSemester)))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "get-names-fail/invalid-semester-format",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordType").description("생활기록부 항목 타입")
                         ),
@@ -404,6 +433,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value(UPDATE_PERMISSION_DENIED.getCode()))
                 .andExpect(jsonPath("$.message").value(UPDATE_PERMISSION_DENIED.getMessage()))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-fail/permission-denied",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("학생의 생기부 레코드 ID")
                         ),
@@ -441,6 +473,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-201"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "create-one-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordType").description("생활기록부 항목 타입")
                         ),
@@ -485,6 +520,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-overview-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("기록 ID")
                         ),
@@ -518,6 +556,9 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "delete-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
                         pathParameters(
                                 parameterWithName("recordId").description("삭제할 생활기록부 ID")
                         ),


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-186]


## 👩‍💻 작업 내용
교사 인증 이메일을 전송하는 API를 구현했습니다.
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용

<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📸 스크린 샷 (선택)
<img width="264" alt="image" src="https://github.com/user-attachments/assets/a8089509-30cf-45e7-9bc6-6c7f6ecbd99e" />


[EDMT-186]: https://bbangbbangz.atlassian.net/browse/EDMT-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
    - 인증 및 학생 정보 API 문서에 요청 헤더(Authorization) 관련 설명이 추가되었습니다.
    - 교사 인증을 위한 이메일 전송 API 문서가 새롭게 추가되었습니다.
- **버그 수정**
    - 학생 정보 목록 테스트의 오타가 수정되었습니다.
- **테스트**
    - 이메일 인증 요청 성공 시나리오에 대한 테스트가 추가되었습니다.
    - API 문서화 테스트에 요청 헤더 검증이 강화되었습니다.
- **리팩터**
    - 이메일 인증 요청 방식이 UUID에서 memberId 기반으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->