### PR TITLE
[EDMT-174] 학기 추가 로직 구현

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -115,3 +115,6 @@ operation::student-record/create-semester-success[snippets="request-headers,path
 
 ==== 실패: 잘못된 학기 형식
 operation::student-record/create-semester-fail/invalid-semester-format[snippets="http-request,http-response"]
+
+==== 실패: 이미 존재하는 학기
+operation::student-record/create-semester-fail/already-exists[snippets="http-request,http-response"]

--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -106,3 +106,12 @@ operation::student-record/fail/record-not-found[snippets="http-request,http-resp
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
 
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]
+
+=== 학기 추가
+
+==== 성공
+
+operation::student-record/create-semester-success[snippets="request-headers,path-parameters,http-request,request-fields,http-response,response-fields"]
+
+==== 실패: 잘못된 학기 형식
+operation::student-record/create-semester-fail/invalid-semester-format[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }
 
-    @PatchMapping("/logout")
+    @PostMapping("/logout")
     public ApiResponse<Void> logout(@MemberId final long memberId) {
         authFacade.logout(memberId);
         return ApiResponse.success(CommonSuccessCode.OK);

--- a/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
@@ -23,6 +23,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     private static final String EMPTY_REFRESH_TOKEN = null;
+    private static final boolean NOT_WITHDRAWN = false;
 
     @Transactional
     public void verifyEmailCode(final Member member, final String inputCode) {
@@ -43,7 +44,7 @@ public class AuthService {
     }
 
     public void checkAlreadyRegistered(final String email) {
-        if (memberRepository.existsByEmail(email)) {
+        if (memberRepository.existsByEmailAndIsDeleted(email, NOT_WITHDRAWN)) {
             throw new MemberAlreadyRegisteredException(AuthErrorCode.MEMBER_ALREADY_REGISTERED);
         }
     }

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -119,4 +119,8 @@ public class Member extends BaseEntity {
     public boolean isVerifyTeacher() {
         return this.role != Role.PENDING_TEACHER;
     }
+
+    public void resign() {
+        this.isDeleted = false;
+    }
 }

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -120,7 +120,12 @@ public class Member extends BaseEntity {
         return this.role != Role.PENDING_TEACHER;
     }
 
-    public void resign() {
+    public void restore(final String password, final Subject subject, final School school) {
         this.isDeleted = false;
+        this.deletedAt = null;
+        this.password = password;
+        this.subject = subject;
+        this.school = school;
+        this.role = Role.PENDING_TEACHER;
     }
 }

--- a/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
+++ b/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<Member> findByMemberUuidAndIsDeleted(String memberUuid, boolean isDeleted);
 }

--- a/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
+++ b/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
@@ -10,7 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
-    boolean existsByEmail(String email);
+    boolean existsByEmailAndIsDeleted(String email, boolean isDeleted);
 
     Optional<Member> findByMemberUuidAndIsDeleted(String memberUuid, boolean isDeleted);
 }

--- a/src/main/java/com/edumate/eduserver/member/service/MemberAuthenticationService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberAuthenticationService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class MemberAuthenticationService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
+    private static final boolean NOT_WITHDRAWN = false;
 
     @Override
     public UserDetails loadUserByUsername(final String memberUuid) {
@@ -29,7 +30,7 @@ public class MemberAuthenticationService implements UserDetailsService {
     }
 
     private Member getMemberByUuid(final String memberUuid) {
-        return memberRepository.findByMemberUuid(memberUuid)
+        return memberRepository.findByMemberUuidAndIsDeleted(memberUuid, NOT_WITHDRAWN)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/edumate/eduserver/member/service/MemberAuthenticationService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberAuthenticationService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,13 +19,9 @@ public class MemberAuthenticationService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(final String memberUuid) {
-        try {
-            Member member = getMemberByUuid(memberUuid);
-            String memberId = String.valueOf(member.getId());
-            return new User(memberId, member.getPassword(), member.getAuthorities());
-        } catch (MemberNotFoundException e) {
-            throw new UsernameNotFoundException("Member not found with UUID: " + memberUuid, e);
-        }
+        Member member = getMemberByUuid(memberUuid);
+        String memberId = String.valueOf(member.getId());
+        return new User(memberId, member.getPassword(), member.getAuthorities());
     }
 
     private Member getMemberByUuid(final String memberUuid) {

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -32,25 +32,24 @@ public class MemberService {
                              final String schoolName) {
         School school = School.fromName(schoolName);
 
-        Optional<Member> restored = restoreIfSoftDeletedMemberByEmail(email);
+        Optional<Member> restored = restoreIfSoftDeletedMemberByEmail(email, password, subject, school);
         if (restored.isPresent()) {
             return restored.get().getMemberUuid();
         }
 
         Member newMember = Member.create(subject, email, password, DEFAULT_NICKNAME, school, INITIAL_ROLE);
         memberRepository.save(newMember);
-
         String generatedNickname = DEFAULT_NICKNAME + newMember.getId();
         newMember.updateNickname(generatedNickname);
-
         return newMember.getMemberUuid();
     }
 
-    private Optional<Member> restoreIfSoftDeletedMemberByEmail(final String email) {
+    private Optional<Member> restoreIfSoftDeletedMemberByEmail(final String email, final String password,
+                                                               final Subject subject, final School school) {
         return memberRepository.findByEmail(email)
                 .filter(Member::isDeleted)
                 .map(member -> {
-                    member.resign();
+                    member.restore(password, subject, school);
                     return member;
                 });
     }

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -3,6 +3,7 @@ package com.edumate.eduserver.studentrecord.controller;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
+import com.edumate.eduserver.studentrecord.controller.request.SemesterCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordOverviewUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordUpdateRequest;
@@ -96,5 +97,13 @@ public class StudentRecordController {
                                                  @PathVariable final long recordId) {
         studentRecordFacade.deleteStudentRecord(memberId, recordId);
         return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
+    @PostMapping("/{recordType}/semesters")
+    public ApiResponse<Void> createStudentRecordForSemester(@MemberId final long memberId,
+                                                            @PathVariable final StudentRecordType recordType,
+                                                            @RequestBody final SemesterCreateRequest request) {
+        studentRecordFacade.createSemesterRecord(memberId, recordType, request.semester().strip());
+        return ApiResponse.success(CommonSuccessCode.CREATED);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -102,7 +102,7 @@ public class StudentRecordController {
     @PostMapping("/{recordType}/semesters")
     public ApiResponse<Void> createStudentRecordForSemester(@MemberId final long memberId,
                                                             @PathVariable final StudentRecordType recordType,
-                                                            @RequestBody final SemesterCreateRequest request) {
+                                                            @RequestBody @Valid final SemesterCreateRequest request) {
         studentRecordFacade.createSemesterRecord(memberId, recordType, request.semester().strip());
         return ApiResponse.success(CommonSuccessCode.CREATED);
     }

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/request/SemesterCreateRequest.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/request/SemesterCreateRequest.java
@@ -1,0 +1,9 @@
+package com.edumate.eduserver.studentrecord.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SemesterCreateRequest(
+        @NotNull(message = "학기 정보는 필수입니다.")
+        String semester
+) {
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/exception/AlreadyExistingRecordException.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/exception/AlreadyExistingRecordException.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.studentrecord.exception;
+
+import com.edumate.eduserver.common.exception.ConflictException;
+import com.edumate.eduserver.studentrecord.exception.code.StudentRecordErrorCode;
+
+public class AlreadyExistingRecordException extends ConflictException {
+
+    public AlreadyExistingRecordException(final StudentRecordErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/studentrecord/exception/code/StudentRecordErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/exception/code/StudentRecordErrorCode.java
@@ -17,8 +17,10 @@ public enum StudentRecordErrorCode implements ErrorCode {
 
     // 404 Not Found,
     STUDENT_RECORD_DETAIL_NOT_FOUND("EDMT-4040202", "해당 학생에 대한 생활기록부 기록이 존재하지 않습니다."),
-    MEMBER_STUDENT_RECORD_NOT_FOUND("EDMT-4040201", "해당 회원의 해당 학기 생활기록부가 존재하지 않습니다.")
-    ;
+    MEMBER_STUDENT_RECORD_NOT_FOUND("EDMT-4040201", "해당 회원의 해당 학기 생활기록부가 존재하지 않습니다."),
+
+    // 409 Conflict
+    RECORD_ALREADY_EXISTS("EDMT-4090201", "이미 해당 학기 생활기록부가 존재합니다. 중복된 기록을 추가할 수 없습니다."),;
 
     private final String code;
     private final String message;

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -1,5 +1,7 @@
 package com.edumate.eduserver.studentrecord.facade;
 
+import com.edumate.eduserver.member.domain.Member;
+import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudentRecordFacade {
 
     private final StudentRecordService studentRecordService;
+    private final MemberService memberService;
 
     @Transactional
     public void updateStudentRecord(final long memberId, final long recordId, final String description,
@@ -67,5 +70,11 @@ public class StudentRecordFacade {
     @Transactional
     public void deleteStudentRecord(final long memberId, final long recordId) {
         studentRecordService.deleteStudentRecord(memberId, recordId);
+    }
+
+    @Transactional
+    public void createSemesterRecord(final long memberId, final StudentRecordType recordType, final String semester) {
+        Member member = memberService.getMemberById(memberId);
+        studentRecordService.createSemesterRecord(member, recordType, semester);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -1,5 +1,6 @@
 package com.edumate.eduserver.studentrecord.service;
 
+import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.MemberStudentRecord;
@@ -95,6 +96,13 @@ public class StudentRecordService {
         StudentRecordDetail existingDetail = getRecordDetailById(recordId);
         validatePermission(existingDetail.getMemberStudentRecord(), memberId);
         studentRecordDetailRepository.deleteById(recordId);
+    }
+
+    @Transactional
+    public void createSemesterRecord(final Member member, final StudentRecordType recordType, final String semester) {
+        validateSemesterPattern(semester);
+        MemberStudentRecord studentRecord = MemberStudentRecord.create(member, recordType, semester);
+        memberStudentRecordRepository.save(studentRecord);
     }
 
     private void validatePermission(final MemberStudentRecord memberRecord, final long memberId) {

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -6,6 +6,7 @@ import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordIn
 import com.edumate.eduserver.studentrecord.domain.MemberStudentRecord;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
+import com.edumate.eduserver.studentrecord.exception.AlreadyExistingRecordException;
 import com.edumate.eduserver.studentrecord.exception.InvalidSemesterFormatException;
 import com.edumate.eduserver.studentrecord.exception.MemberStudentRecordNotFoundException;
 import com.edumate.eduserver.studentrecord.exception.StudentRecordDetailNotFoundException;
@@ -46,16 +47,19 @@ public class StudentRecordService {
 
     private StudentRecordDetail getRecordDetailById(final long recordId) {
         return studentRecordDetailRepository.findById(recordId)
-                .orElseThrow(() -> new StudentRecordDetailNotFoundException(StudentRecordErrorCode.STUDENT_RECORD_DETAIL_NOT_FOUND));
+                .orElseThrow(() -> new StudentRecordDetailNotFoundException(
+                        StudentRecordErrorCode.STUDENT_RECORD_DETAIL_NOT_FOUND));
     }
 
-    public List<StudentRecordDetail> getAll(final long memberId, final StudentRecordType recordType, final String semester) {
+    public List<StudentRecordDetail> getAll(final long memberId, final StudentRecordType recordType,
+                                            final String semester) {
         validateSemesterPattern(semester);
         MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
         return findRecordDetails(memberStudentRecord);
     }
 
-    public List<StudentRecordDetail> getStudentNames(final long memberId, final StudentRecordType recordType, final String semester) {
+    public List<StudentRecordDetail> getStudentNames(final long memberId, final StudentRecordType recordType,
+                                                     final String semester) {
         validateSemesterPattern(semester);
         MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
         return findRecordDetails(memberStudentRecord);
@@ -66,15 +70,17 @@ public class StudentRecordService {
                                      final List<StudentRecordInfo> studentRecordInfos) {
         MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
         List<StudentRecordDetail> details = studentRecordInfos.stream()
-                .map(studentRecord -> StudentRecordDetail.create(memberStudentRecord, studentRecord.studentNumber(), studentRecord.studentName(),
+                .map(studentRecord -> StudentRecordDetail.create(memberStudentRecord, studentRecord.studentNumber(),
+                        studentRecord.studentName(),
                         INITIAL_DESCRIPTION, INITIAL_BYTE_COUNT))
                 .toList();
         studentRecordDetailRepository.saveAll(details);
     }
 
     @Transactional
-    public StudentRecordDetail createStudentRecord(final long memberId, final StudentRecordType recordType, final String semester,
-                                    final StudentRecordCreateInfo studentRecordCreateInfo) {
+    public StudentRecordDetail createStudentRecord(final long memberId, final StudentRecordType recordType,
+                                                   final String semester,
+                                                   final StudentRecordCreateInfo studentRecordCreateInfo) {
         validateSemesterPattern(semester);
         MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
         StudentRecordDetail studentRecordDetail = StudentRecordDetail.create(memberStudentRecord,
@@ -101,8 +107,16 @@ public class StudentRecordService {
     @Transactional
     public void createSemesterRecord(final Member member, final StudentRecordType recordType, final String semester) {
         validateSemesterPattern(semester);
+        validateExistingRecord(member.getId(), recordType, semester);
         MemberStudentRecord studentRecord = MemberStudentRecord.create(member, recordType, semester);
         memberStudentRecordRepository.save(studentRecord);
+    }
+
+    private void validateExistingRecord(final long memberId, final StudentRecordType recordType, final String semester) {
+        memberStudentRecordRepository.findByMemberIdAndStudentRecordTypeAndSemester(memberId, recordType, semester)
+                .ifPresent(record -> {
+                    throw new AlreadyExistingRecordException(StudentRecordErrorCode.RECORD_ALREADY_EXISTS);
+                });
     }
 
     private void validatePermission(final MemberStudentRecord memberRecord, final long memberId) {
@@ -117,8 +131,10 @@ public class StudentRecordService {
         }
     }
 
-    private MemberStudentRecord getMemberStudentRecord(final long memberId, final StudentRecordType recordType, final String semester) {
-        return memberStudentRecordRepository.findByMemberIdAndStudentRecordTypeAndSemester(memberId, recordType, semester)
+    private MemberStudentRecord getMemberStudentRecord(final long memberId, final StudentRecordType recordType,
+                                                       final String semester) {
+        return memberStudentRecordRepository.findByMemberIdAndStudentRecordTypeAndSemester(memberId, recordType,
+                        semester)
                 .orElseThrow(() -> new MemberStudentRecordNotFoundException(
                         StudentRecordErrorCode.MEMBER_STUDENT_RECORD_NOT_FOUND));
     }

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -412,7 +412,7 @@ class AuthControllerTest extends ControllerTest {
     void logoutSuccess() throws Exception {
         doNothing().when(authFacade).logout(anyLong());
 
-        mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/logout")
+        mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/logout")
                         .header("Authorization", "Bearer access-token"))
                 .andDo(print())
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-174]


## 👩‍💻 작업 내용
학기 추가 API를 구현했습니다.
추가로, 인증 관련 필터도 약간 손봤습니다.

## 📸 스크린 샷 (선택)
![image](https://github.com/user-attachments/assets/28d8138c-15ef-4c1c-958c-084266adb46a)


[EDMT-174]: https://bbangbbangz.atlassian.net/browse/EDMT-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 학생 기록에 학기별 기록 추가 기능이 도입되었습니다. 사용자는 새로운 학기 정보를 입력하여 학생 기록을 생성할 수 있습니다.
    - 소프트 삭제된 회원 계정을 복원하는 기능이 추가되어, 기존 회원 정보를 재사용할 수 있습니다.

- **버그 수정**
    - 로그아웃 API의 HTTP 메서드가 PATCH에서 POST로 변경되어 보다 일관된 사용 경험을 제공합니다.

- **문서화**
    - 학생 기록 API 문서에 학기 추가 및 실패 사례가 상세히 추가되었습니다.

- **테스트**
    - 학기별 학생 기록 생성 성공 및 실패 케이스에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->