### PR TITLE
[EDMT-156]

### DIFF
--- a/src/main/java/com/edumate/eduserver/auth/exception/MismatchedTokenException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/MismatchedTokenException.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.auth.exception;
+
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
+import com.edumate.eduserver.common.exception.UnauthorizedException;
+
+public class MismatchedTokenException extends UnauthorizedException {
+
+    public MismatchedTokenException(final AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -85,7 +85,13 @@ public class AuthFacade {
     public MemberReissueResponse reissue(final String refreshToken) {
         String memberUuid = tokenService.getMemberUuidFromToken(refreshToken);
         Member member = memberService.getMemberByUuid(memberUuid);
-        Token token = tokenService.generateTokens(member);
-        return MemberReissueResponse.of(token.accessToken(), token.refreshToken());
+        try {
+            tokenService.validateToken(refreshToken, member.getRefreshToken());
+            Token token = tokenService.generateTokens(member);
+            return MemberReissueResponse.of(token.accessToken(), token.refreshToken());
+        } catch (Exception e) {
+            logout(member.getId());
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/facade/dto/MemberSignedUpEvent.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/dto/MemberSignedUpEvent.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.auth.facade.dto;
+
+public record MemberSignedUpEvent(
+        String email,
+        String memberUuid,
+        String verificationCode
+) {
+    public static MemberSignedUpEvent of(final String email, final String memberUuid, final String verificationCode) {
+        return new MemberSignedUpEvent(email, memberUuid, verificationCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/service/EmailEventListener.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/EmailEventListener.java
@@ -1,0 +1,21 @@
+package com.edumate.eduserver.auth.service;
+
+import com.edumate.eduserver.auth.facade.dto.MemberSignedUpEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class EmailEventListener {
+
+    private final EmailService emailService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEmailEvent(MemberSignedUpEvent event) {
+        emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode());
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/service/EmailService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/EmailService.java
@@ -32,7 +32,8 @@ public class EmailService {
         if (httpResponse.isSuccessful()) {
             log.info("Email sent successfully to {}. Response: {}", emailReceiver, result);
         } else {
-            log.error("Failed to send email to {}. Response: {}. Status Code: {}", emailReceiver, result, httpResponse.statusCode());
+            log.error("Failed to send email to {}. Response: {}. Status Code: {}", emailReceiver, result,
+                    httpResponse.statusCode());
         }
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -1,5 +1,7 @@
 package com.edumate.eduserver.auth.service;
 
+import com.edumate.eduserver.auth.exception.MismatchedTokenException;
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.auth.security.jwt.JwtGenerator;
 import com.edumate.eduserver.auth.security.jwt.JwtParser;
 import com.edumate.eduserver.auth.security.jwt.JwtValidator;
@@ -29,7 +31,14 @@ public class TokenService {
 
     public String getMemberUuidFromToken(final String refreshToken) {
         String prefixRemovedToken = jwtParser.resolveToken(refreshToken);
-        jwtValidator.validateToken(prefixRemovedToken, TokenType.REFRESH);
         return jwtParser.getMemberUuidFromToken(prefixRemovedToken);
+    }
+
+    public void validateToken(final String requestRefreshToken, final String storedRefreshToken) {
+        String prefixRemovedToken = jwtParser.resolveToken(requestRefreshToken);
+        jwtValidator.validateToken(prefixRemovedToken, TokenType.REFRESH);
+        if (!storedRefreshToken.equals(prefixRemovedToken)) {
+            throw new MismatchedTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN_VALUE);
+        }
     }
 }

--- a/src/main/java/com/edumate/eduserver/common/config/AsyncConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.edumate.eduserver.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+}


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-156]


## 👩‍💻 작업 내용
회원가입 시 인증 메일을 비동기적으로 전송하고, 트랜잭션 커밋 이후 실행되도록 이벤트 기반 구조로 리팩토링했습니다.
- 메일 전송(AWS SES)은 외부 I/O이며, 지연 또는 실패 가능성이 있으므로 회원가입 흐름과 분리 필요
- 트랜잭션 커밋 이전에 메일을 전송할 경우, 트랜잭션 롤백 시에도 메일이 발송되는 문제가 발생함
- `@TransactionalEventListener(phase = AFTER_COMMIT)`을 통해 트랜잭션 성공 후에만 메일 전송되도록 설계
- `@Async`를 통해 메일 전송 지연이 사용자 응답 속도에 영향을 주지 않도록 처리
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용
현재 서버의 코어 수에 적절한 ThreadPool 설정 등은 나중에 찾아보고 설정하겠습니다!
