### PR TITLE
[EDMT-187] 학기 추가 API 삭제

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -106,15 +106,3 @@ operation::student-record/fail/record-not-found[snippets="http-request,http-resp
 ==== 실패: 권한이 없음 (해당 생기부의 주인이 아님)
 
 operation::student-record/update-fail/permission-denied[snippets="http-request,http-response"]
-
-=== 학기 추가
-
-==== 성공
-
-operation::student-record/create-semester-success[snippets="request-headers,path-parameters,http-request,request-fields,http-response,response-fields"]
-
-==== 실패: 잘못된 학기 형식
-operation::student-record/create-semester-fail/invalid-semester-format[snippets="http-request,http-response"]
-
-==== 실패: 이미 존재하는 학기
-operation::student-record/create-semester-fail/already-exists[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/controller/StudentRecordController.java
@@ -3,7 +3,6 @@ package com.edumate.eduserver.studentrecord.controller;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
-import com.edumate.eduserver.studentrecord.controller.request.SemesterCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordCreateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordOverviewUpdateRequest;
 import com.edumate.eduserver.studentrecord.controller.request.StudentRecordUpdateRequest;
@@ -97,13 +96,5 @@ public class StudentRecordController {
                                                  @PathVariable final long recordId) {
         studentRecordFacade.deleteStudentRecord(memberId, recordId);
         return ApiResponse.success(CommonSuccessCode.OK);
-    }
-
-    @PostMapping("/{recordType}/semesters")
-    public ApiResponse<Void> createStudentRecordForSemester(@MemberId final long memberId,
-                                                            @PathVariable final StudentRecordType recordType,
-                                                            @RequestBody @Valid final SemesterCreateRequest request) {
-        studentRecordFacade.createSemesterRecord(memberId, recordType, request.semester().strip());
-        return ApiResponse.success(CommonSuccessCode.CREATED);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -4,6 +4,7 @@ import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
+import com.edumate.eduserver.studentrecord.domain.MemberStudentRecord;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
 import com.edumate.eduserver.studentrecord.facade.response.StudentNamesResponse;
@@ -52,8 +53,8 @@ public class StudentRecordFacade {
     public void createStudentRecords(final long memberId, final StudentRecordType recordType, final String semester,
                                      final List<StudentRecordInfo> studentRecordInfos) {
         Member member = memberService.getMemberById(memberId);
-        studentRecordService.createSemesterRecord(member, recordType, semester);
-        studentRecordService.createStudentRecords(memberId, recordType, semester, studentRecordInfos);
+        MemberStudentRecord studentRecord = studentRecordService.createSemesterRecord(member, recordType, semester);
+        studentRecordService.createStudentRecords(studentRecord, studentRecordInfos);
     }
 
     @Transactional

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -51,6 +51,8 @@ public class StudentRecordFacade {
     @Transactional
     public void createStudentRecords(final long memberId, final StudentRecordType recordType, final String semester,
                                      final List<StudentRecordInfo> studentRecordInfos) {
+        Member member = memberService.getMemberById(memberId);
+        studentRecordService.createSemesterRecord(member, recordType, semester);
         studentRecordService.createStudentRecords(memberId, recordType, semester, studentRecordInfos);
     }
 
@@ -70,11 +72,5 @@ public class StudentRecordFacade {
     @Transactional
     public void deleteStudentRecord(final long memberId, final long recordId) {
         studentRecordService.deleteStudentRecord(memberId, recordId);
-    }
-
-    @Transactional
-    public void createSemesterRecord(final long memberId, final StudentRecordType recordType, final String semester) {
-        Member member = memberService.getMemberById(memberId);
-        studentRecordService.createSemesterRecord(member, recordType, semester);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -78,6 +78,14 @@ public class StudentRecordService {
     }
 
     @Transactional
+    public void createSemesterRecord(final Member member, final StudentRecordType recordType, final String semester) {
+        validateSemesterPattern(semester);
+        validateExistingRecord(member.getId(), recordType, semester);
+        MemberStudentRecord studentRecord = MemberStudentRecord.create(member, recordType, semester);
+        memberStudentRecordRepository.save(studentRecord);
+    }
+
+    @Transactional
     public StudentRecordDetail createStudentRecord(final long memberId, final StudentRecordType recordType,
                                                    final String semester,
                                                    final StudentRecordCreateInfo studentRecordCreateInfo) {
@@ -102,14 +110,6 @@ public class StudentRecordService {
         StudentRecordDetail existingDetail = getRecordDetailById(recordId);
         validatePermission(existingDetail.getMemberStudentRecord(), memberId);
         studentRecordDetailRepository.deleteById(recordId);
-    }
-
-    @Transactional
-    public void createSemesterRecord(final Member member, final StudentRecordType recordType, final String semester) {
-        validateSemesterPattern(semester);
-        validateExistingRecord(member.getId(), recordType, semester);
-        MemberStudentRecord studentRecord = MemberStudentRecord.create(member, recordType, semester);
-        memberStudentRecordRepository.save(studentRecord);
     }
 
     public MemberStudentRecord getLatestMemberStudentRecord(final long memberId) {

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -66,9 +66,7 @@ public class StudentRecordService {
     }
 
     @Transactional
-    public void createStudentRecords(final long memberId, final StudentRecordType recordType, final String semester,
-                                     final List<StudentRecordInfo> studentRecordInfos) {
-        MemberStudentRecord memberStudentRecord = getMemberStudentRecord(memberId, recordType, semester);
+    public void createStudentRecords(final MemberStudentRecord memberStudentRecord, final List<StudentRecordInfo> studentRecordInfos) {
         List<StudentRecordDetail> details = studentRecordInfos.stream()
                 .map(studentRecord -> StudentRecordDetail.create(memberStudentRecord, studentRecord.studentNumber(),
                         studentRecord.studentName(),
@@ -78,11 +76,12 @@ public class StudentRecordService {
     }
 
     @Transactional
-    public void createSemesterRecord(final Member member, final StudentRecordType recordType, final String semester) {
+    public MemberStudentRecord createSemesterRecord(final Member member, final StudentRecordType recordType, final String semester) {
         validateSemesterPattern(semester);
         validateExistingRecord(member.getId(), recordType, semester);
         MemberStudentRecord studentRecord = MemberStudentRecord.create(member, recordType, semester);
         memberStudentRecordRepository.save(studentRecord);
+        return studentRecord;
     }
 
     @Transactional

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -6,9 +6,11 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
+import com.edumate.eduserver.studentrecord.domain.MemberStudentRecord;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordType;
 import com.edumate.eduserver.studentrecord.facade.response.StudentNamesResponse;
@@ -94,17 +96,31 @@ class StudentRecordFacadeTest {
     }
 
     @Test
-    @DisplayName("학생 기록 생성이 정상 동작한다.")
+    @DisplayName("다수의 학생 기록 생성이 정상 동작한다.")
     void createStudentRecords() {
+        // given
         long memberId = 500L;
-        StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
-        String semester = "2024-2";
-        List<StudentRecordInfo> infos = List.of(mock(StudentRecordInfo.class));
-        willDoNothing().given(studentRecordService).createStudentRecords(memberId, type, semester, infos);
+        StudentRecordType type = StudentRecordType.BEHAVIOR_OPINION;
+        String semester = "2025-1";
+        List<StudentRecordInfo> studentRecordInfos = List.of(
+                new StudentRecordInfo("2023001", "김학생"),
+                new StudentRecordInfo("2023002", "이학생")
+        );
 
-        studentRecordFacade.createStudentRecords(memberId, type, semester, infos);
+        Member mockMember = mock(Member.class);
+        MemberStudentRecord mockRecord = mock(MemberStudentRecord.class);
 
-        verify(studentRecordService).createStudentRecords(memberId, type, semester, infos);
+        given(memberService.getMemberById(memberId)).willReturn(mockMember);
+        given(studentRecordService.createSemesterRecord(mockMember, type, semester)).willReturn(mockRecord);
+        willDoNothing().given(studentRecordService).createStudentRecords(mockRecord, studentRecordInfos);
+
+        // when
+        studentRecordFacade.createStudentRecords(memberId, type, semester, studentRecordInfos);
+
+        // then
+        verify(memberService).getMemberById(memberId);
+        verify(studentRecordService).createSemesterRecord(mockMember, type, semester);
+        verify(studentRecordService).createStudentRecords(mockRecord, studentRecordInfos);
     }
 
     @Test
@@ -141,7 +157,7 @@ class StudentRecordFacadeTest {
     }
 
     @Test
-    @DisplayName("생활기록부 삭제가 정상 동작한다.")
+    @DisplayName("생활기록부 삭제가 정상 동작��다.")
     void deleteStudentRecordFacade() {
         long memberId = 300L;
         long recordId = 3L;
@@ -153,4 +169,3 @@ class StudentRecordFacadeTest {
         verify(studentRecordService).deleteStudentRecord(memberId, recordId);
     }
 }
-


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-187]


## 👩‍💻 작업 내용
기획 변경에 따라 학기 추가 API를 학생 추가 API 기능에 통합했습니다.
<!-- 작업 내용을 적어주세요 -->

## 📸 스크린 샷 (선택)
<img width="276" alt="image" src="https://github.com/user-attachments/assets/692c62c3-1058-4488-b3e2-83cecdf2d6e2" />


[EDMT-187]: https://bbangbbangz.atlassian.net/browse/EDMT-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서화**
  - "학기 추가" 관련 API 문서 및 성공/실패 응답 예시가 삭제되었습니다.

- **버그 수정**
  - 잘못된 학기 형식으로 여러 학생 기록을 생성할 때 올바른 오류 코드와 메시지가 반환되는지 확인하는 테스트가 추가되었습니다.

- **테스트**
  - 학기 추가 엔드포인트 관련 테스트가 삭제되고, 여러 학생 기록 생성 시 학기 형식 오류에 대한 테스트가 추가되었습니다.
  - 학생 생활기록부 생성 관련 서비스 및 퍼사드 테스트가 리팩토링되어, 여러 학생 기록을 한 번에 생성하는 방식으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->