### PR TITLE
[EDMT-191] 생활기록부 목록 조회 API 테스트 코드 추가

### DIFF
--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -75,6 +75,10 @@ operation::student-record/get-names-fail/invalid-semester-format[snippets=http-r
 
 operation::student-record/get-overviews-success[snippets="http-request,request-headers,path-parameters,query-parameters,http-response,response-fields"]
 
+==== 실패: 유효하지 않은 학기 형식
+
+operation::student-record/get-names-fail/invalid-semester-format[snippets=http-response]
+
 === 생활기록부 한 명 추가
 
 ==== 성공

--- a/src/docs/asciidoc/api/studentRecord.adoc
+++ b/src/docs/asciidoc/api/studentRecord.adoc
@@ -69,6 +69,12 @@ operation::student-record/fail/member-record-not-found[snippets="http-response"]
 
 operation::student-record/get-names-fail/invalid-semester-format[snippets=http-response]
 
+=== 생활기록부 목록 조회
+
+==== 성공
+
+operation::student-record/get-overviews-success[snippets="http-request,request-headers,path-parameters,query-parameters,http-response,response-fields"]
+
 === 생활기록부 한 명 추가
 
 ==== 성공

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -43,7 +43,9 @@ import com.edumate.eduserver.studentrecord.exception.UpdatePermissionDeniedExcep
 import com.edumate.eduserver.studentrecord.facade.StudentRecordFacade;
 import com.edumate.eduserver.studentrecord.facade.response.StudentNamesResponse;
 import com.edumate.eduserver.studentrecord.facade.response.StudentRecordDetailResponse;
+import com.edumate.eduserver.studentrecord.facade.response.StudentRecordOverviewsResponse;
 import com.edumate.eduserver.studentrecord.facade.response.vo.StudentDetail;
+import com.edumate.eduserver.studentrecord.facade.response.vo.StudentRecordOverview;
 import com.edumate.eduserver.util.ControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -610,6 +612,48 @@ class StudentRecordControllerTest extends ControllerTest {
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("message").description("응답 메시지")
                         )
+                ));
+    }
+
+    @Test
+    @DisplayName("생활기록부 목록을 성공적으로 불러온다.")
+    void getStudentRecordOverviews() throws Exception {
+        // given
+        StudentRecordOverviewsResponse dummyResponse = new StudentRecordOverviewsResponse(List.of(
+                StudentRecordOverview.of(1L, "2020123", "유태근", "프로그래밍 동아리 활동"),
+                StudentRecordOverview.of(2L, "2020456", "김지안", "봉사 동아리 리더")
+        ));
+        when(studentRecordFacade.getStudentRecordOverviews(anyLong(), any(StudentRecordType.class), anyString()))
+                .thenReturn(dummyResponse);
+
+        // when & then
+        mockMvc.perform(get(BASE_URL + "/{recordType}", RECORD_TYPE)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .param("semester", "2025-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "get-overviews-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
+                        pathParameters(
+                                parameterWithName("recordType").description("생활기록부 항목 타입")
+                        ),
+                        queryParameters(
+                                parameterWithName("semester").description("학기 (YYYY-1 또는 YYYY-2 형식)")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.students[].recordDetailId").description("레코드 상세 ID"),
+                                fieldWithPath("data.students[].studentNumber").description("학번"),
+                                fieldWithPath("data.students[].studentName").description("학생 이름"),
+                                fieldWithPath("data.students[].description").description("생기부 내용")
+                        )
+
                 ));
     }
 }

--- a/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/controller/StudentRecordControllerTest.java
@@ -4,6 +4,7 @@ import static com.edumate.eduserver.studentrecord.exception.code.StudentRecordEr
 import static com.edumate.eduserver.studentrecord.exception.code.StudentRecordErrorCode.MEMBER_STUDENT_RECORD_NOT_FOUND;
 import static com.edumate.eduserver.studentrecord.exception.code.StudentRecordErrorCode.STUDENT_RECORD_DETAIL_NOT_FOUND;
 import static com.edumate.eduserver.studentrecord.exception.code.StudentRecordErrorCode.UPDATE_PERMISSION_DENIED;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -634,6 +635,8 @@ class StudentRecordControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.code").value("EDMT-200"))
                 .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andExpect(jsonPath("$.data.students", hasSize(2)))
+                .andExpect(jsonPath("$.data.students[0].studentNumber").value("2020123"))
                 .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "get-overviews-success",
                         requestHeaders(
                                 headerWithName("Authorization").description("액세스 토큰")


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-191]

## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
생활기록부 목록을 조회하는 API의 테스트 코드를 작성한다.

[EDMT-191]: https://bbangbbangz.atlassian.net/browse/EDMT-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
  - 학생 생활기록부 목록 조회 API의 성공 사례에 대한 문서가 추가되었습니다.

- **테스트**
  - 학생 생활기록부 목록 조회 API의 정상 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->