### PR TITLE
[EDMT-178] 로그인 전 비밀번호 찾기

### DIFF
--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -65,3 +65,26 @@ operation::auth/logout-success[snippets="http-request,request-headers,http-respo
 ==== 성공
 
 operation::auth/reissue-success[snippets="http-request,request-headers,http-response,response-fields"]
+
+==== 실패: 리프레시 토큰 만료
+operation::auth/reissue-fail/expired-token[snippets="http-request,http-response"]
+
+==== 실패: 리프레시 토큰이 일치하지 않음
+operation::auth/reissue-fail/invalid-token[snippets="http-request,http-response"]
+
+=== 로그인 전 비밀번호 찾기(변경)
+
+==== 성공
+operation::auth/update-password-success[snippets="http-request,request-fields,http-response,response-fields"]
+
+==== 실패: 유효하지 않은 비밀번호 형식
+operation::auth/update-password-fail/invalid-password-format[snippets="http-request,http-response"]
+
+==== 실패: 유효하지 않은 비밀번호 길이
+operation::auth/update-password-fail/invalid-password-length[snippets="http-request,http-response"]
+
+==== 실패: 사용자를 찾을 수 없음
+operation::auth/update-password-fail/member-not-found[snippets="http-request,http-response"]
+
+==== 실패: 이전과 동일한 비밀번호
+operation::auth/update-password-fail/password-repetition[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.edumate.eduserver.auth.controller;
 
 import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
 import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
+import com.edumate.eduserver.auth.controller.request.UpdatePasswordRequest;
 import com.edumate.eduserver.auth.facade.AuthFacade;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
@@ -61,8 +62,15 @@ public class AuthController {
     }
 
     @PatchMapping("/reissue")
-    public ApiResponse<MemberReissueResponse> reissue(@RequestHeader(HttpHeaders.AUTHORIZATION) final String refreshToken) {
+    public ApiResponse<MemberReissueResponse> reissue(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) final String refreshToken) {
         MemberReissueResponse response = authFacade.reissue(refreshToken.strip());
         return ApiResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @PatchMapping("/password")
+    public ApiResponse<Void> updatePassword(@RequestBody @Valid final UpdatePasswordRequest request) {
+        authFacade.updatePassword(request.email().strip(), request.password().strip());
+        return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/controller/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/request/UpdatePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.edumate.eduserver.auth.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdatePasswordRequest(
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        @NotNull(message = "이메일 주소를 입력해주세요.")
+        String email,
+        @NotNull(message = "새로 설정하실 비밀번호를 입력해주세요.")
+        String password
+) {
+}

--- a/src/main/java/com/edumate/eduserver/auth/exception/PasswordSameAsOldException.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/PasswordSameAsOldException.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.auth.exception;
+
+import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
+import com.edumate.eduserver.common.exception.BadRequestException;
+
+public class PasswordSameAsOldException extends BadRequestException {
+
+    public PasswordSameAsOldException(final AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_CODE("EDMT-4000103", "유효하지 않은 인증 코드입니다."),
     INVALID_PASSWORD_LENGTH("EDMT-4000104", "비밀번호는 8자 이상 16자 이하로 입력해주세요."),
     INVALID_PASSWORD_FORMAT("EDMT-4000105", "영문, 숫자, 특수문자 중 2종류 이상을 포함해야하며 같은 문자를 3번 이상 연속해서 사용할 수 없습니다."),
+    SAME_PASSWORD("EDMT-4000106", "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."),
 
     // 401 Unauthorized,
     INVALID_ACCESS_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),

--- a/src/main/java/com/edumate/eduserver/auth/service/PasswordValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/PasswordValidator.java
@@ -8,20 +8,15 @@ import java.util.regex.Pattern;
 public class PasswordValidator {
 
     private static final Pattern LENGTH_PATTERN = Pattern.compile("^.{8,16}$");
-    private static final Pattern VALID_PASSWORD_PATTERN = Pattern.compile(
-            "^(?!.*(.)\\1{2})" + // 같은 문자 3번 이상 연속 불가
-                    "(?=.{8,16}$)" +     // 길이: 8~16자
-                    "(" +
-                    "(?=.*[A-Za-z])(?=.*\\d)" + // 영문 + 숫자
-                    "|" +
-                    "(?=.*[A-Za-z])(?=.*[!@#$%^&*()\\-_=+\\[\\]{};:'\",.<>/?`~])" + // 영문 + 특수문자
-                    "|" +
-                    "(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{};:'\",.<>/?`~])" + // 숫자 + 특수문자
-                    ")" +
-                    "[A-Za-z\\d!@#$%^&*()\\-_=+\\[\\]{};:'\",.<>/?`~]*$" // 허용 문자만
+    private static final Pattern VALID_PASSWORD_PATTERN = Pattern.compile("^(?!.*(.)\\1{2})" + // 같은 문자 3번 이상 연속 불가
+            "(?=.{8,16}$)" +     // 길이: 8~16자
+            "(" + "(?=.*[A-Za-z])(?=.*\\d)" + // 영문 + 숫자
+            "|" + "(?=.*[A-Za-z])(?=.*[!@#$%^&*()\\-_=+\\[\\]{};:'\",.<>/?`~])" + // 영문 + 특수문자
+            "|" + "(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[\\]{};:'\",.<>/?`~])" + // 숫자 + 특수문자
+            ")" + "[A-Za-z\\d!@#$%^&*()\\-_=+\\[\\]{};:'\",.<>/?`~]*$" // 허용 문자만
     );
 
-    public static void validate(final String password) {
+    public static void validatePasswordFormat(final String password) {
         if (!LENGTH_PATTERN.matcher(password).matches()) {
             throw new InvalidPasswordLengthException(AuthErrorCode.INVALID_PASSWORD_LENGTH);
         }

--- a/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
             "/api/v1/auth/signup",
             "/api/v1/auth/login",
             "/api/v1/auth/reissue",
+            "/api/v1/auth/password",
             "/api/v1/auth/verify-email",
             "/actuator/health"
     };

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -120,6 +120,10 @@ public class Member extends BaseEntity {
         return this.role != Role.PENDING_TEACHER;
     }
 
+    public void updatePassword(final String password) {
+        this.password = password;
+    }
+
     public void restore(final String password, final Subject subject, final School school) {
         this.isDeleted = false;
         this.deletedAt = null;

--- a/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
+++ b/src/main/java/com/edumate/eduserver/member/repository/MemberRepository.java
@@ -8,7 +8,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByMemberUuid(String memberUuid);
 
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndIsDeleted(String email, boolean isDeleted);
 
     boolean existsByEmailAndIsDeleted(String email, boolean isDeleted);
 

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -21,6 +21,8 @@ public class MemberService {
 
     private static final Role INITIAL_ROLE = Role.PENDING_TEACHER;
     private static final String DEFAULT_NICKNAME = "선생님";
+    private static final boolean NOT_DELETED = false;
+    private static final boolean DELETED = true;
 
     @Transactional
     public void updateEmailVerified(final Member member) {
@@ -46,12 +48,16 @@ public class MemberService {
 
     private Optional<Member> restoreIfSoftDeletedMemberByEmail(final String email, final String password,
                                                                final Subject subject, final School school) {
-        return memberRepository.findByEmail(email)
-                .filter(Member::isDeleted)
+        return memberRepository.findByEmailAndIsDeleted(email, DELETED)
                 .map(member -> {
                     member.restore(password, subject, school);
                     return member;
                 });
+    }
+
+    @Transactional
+    public void updatePassword(final Member member, final String encodedPassword) {
+        member.updatePassword(encodedPassword);
     }
 
     public Member getMemberById(final long memberId) {
@@ -65,7 +71,7 @@ public class MemberService {
     }
 
     public Member getMemberByEmail(final String email) {
-        return memberRepository.findByEmail(email)
+        return memberRepository.findByEmailAndIsDeleted(email, NOT_DELETED)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -19,8 +19,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
 import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
+import com.edumate.eduserver.auth.controller.request.UpdatePasswordRequest;
 import com.edumate.eduserver.auth.exception.AuthCodeNotFoundException;
 import com.edumate.eduserver.auth.exception.ExpiredCodeException;
+import com.edumate.eduserver.auth.exception.InvalidPasswordFormatException;
+import com.edumate.eduserver.auth.exception.InvalidPasswordLengthException;
 import com.edumate.eduserver.auth.exception.MemberAlreadyRegisteredException;
 import com.edumate.eduserver.auth.exception.MisMatchedCodeException;
 import com.edumate.eduserver.auth.exception.MismatchedPasswordException;
@@ -483,5 +486,118 @@ class AuthControllerTest extends ControllerTest {
                         )
                 ));
         verify(authFacade).sendVerificationEmail(anyLong());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경에 성공한다.")
+    void updatePasswordSuccess() throws Exception {
+        UpdatePasswordRequest request = new UpdatePasswordRequest("test@email.com", "newPassword123!");
+        doNothing().when(authFacade).updatePassword(request.email().strip(), request.password().strip());
+
+        mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-password-success",
+                        requestFields(
+                                fieldWithPath("email").description("회원 이메일"),
+                                fieldWithPath("password").description("새 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
+                        )
+                ));
+
+        verify(authFacade).updatePassword(request.email().strip(), request.password().strip());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원으로 비밀번호 변경 시 예외가 발생한다.")
+    void updatePasswordMemberNotFound() throws Exception {
+        UpdatePasswordRequest request = new UpdatePasswordRequest("notfound@email.com", "newPassword123!");
+        doThrow(new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND))
+                .when(authFacade).updatePassword(anyString(), anyString());
+
+        mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value(MemberErrorCode.MEMBER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-password-fail/member-not-found",
+                        requestFields(
+                                fieldWithPath("email").description("회원 이메일"),
+                                fieldWithPath("password").description("새 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("에러 코드"),
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("비밀번호 길이 오류로 비밀번호 변경 시 예외가 발생한다.")
+    void updatePasswordInvalidPasswordLength() throws Exception {
+        UpdatePasswordRequest request = new UpdatePasswordRequest("test@email.com", "short");
+        doThrow(new InvalidPasswordLengthException(AuthErrorCode.INVALID_PASSWORD_LENGTH))
+                .when(authFacade).updatePassword(anyString(), anyString());
+
+        mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.INVALID_PASSWORD_LENGTH.getCode()))
+                .andExpect(jsonPath("$.message").value(AuthErrorCode.INVALID_PASSWORD_LENGTH.getMessage()))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-password-fail/invalid-password-length",
+                        requestFields(
+                                fieldWithPath("email").description("회원 이메일"),
+                                fieldWithPath("password").description("새 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("에러 코드"),
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("비밀번호 형식 오류로 비밀번호 변경 시 예외가 발생한다.")
+    void updatePasswordInvalidPasswordFormat() throws Exception {
+        UpdatePasswordRequest request = new UpdatePasswordRequest("test@email.com", "password");
+        doThrow(new InvalidPasswordFormatException(AuthErrorCode.INVALID_PASSWORD_FORMAT))
+                .when(authFacade).updatePassword(anyString(), anyString());
+
+        mockMvc.perform(RestDocumentationRequestBuilders.patch(BASE_URL + "/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.INVALID_PASSWORD_FORMAT.getCode()))
+                .andExpect(jsonPath("$.message").value(AuthErrorCode.INVALID_PASSWORD_FORMAT.getMessage()))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-password-fail/invalid-password-format",
+                        requestFields(
+                                fieldWithPath("email").description("회원 이메일"),
+                                fieldWithPath("password").description("새 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("에러 코드"),
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
     }
 }

--- a/src/test/java/com/edumate/eduserver/auth/service/PasswordValidatorTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/service/PasswordValidatorTest.java
@@ -13,20 +13,20 @@ class PasswordValidatorTest {
     @Test
     @DisplayName("정상적인 비밀번호는 예외가 발생하지 않는다.")
     void validPassword() {
-        assertThatCode(() -> PasswordValidator.validate("Abcdef12!"))
+        assertThatCode(() -> PasswordValidator.validatePasswordFormat("Abcdef12!"))
                 .doesNotThrowAnyException();
-        assertThatCode(() -> PasswordValidator.validate("1234abcd@"))
+        assertThatCode(() -> PasswordValidator.validatePasswordFormat("1234abcd@"))
                 .doesNotThrowAnyException();
-        assertThatCode(() -> PasswordValidator.validate("a1!b2@c3#"))
+        assertThatCode(() -> PasswordValidator.validatePasswordFormat("a1!b2@c3#"))
                 .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("비밀번호가 8자 미만 또는 16자 초과면 InvalidPasswordLengthException이 발생한다.")
     void invalidPasswordLength() {
-        assertThatThrownBy(() -> PasswordValidator.validate("Abc12!"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("Abc12!"))
                 .isInstanceOf(InvalidPasswordLengthException.class);
-        assertThatThrownBy(() -> PasswordValidator.validate("a1!b2@c3#d4$e5%f6^g7&"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("a1!b2@c3#d4$e5%f6^g7&"))
                 .isInstanceOf(InvalidPasswordLengthException.class);
     }
 
@@ -34,24 +34,24 @@ class PasswordValidatorTest {
     @DisplayName("비밀번호가 영문, 숫자, 특수문자 중 2종류 이상을 포함하지 않으면 InvalidPasswordFormatException이 발생한다.")
     void invalidPasswordFormat() {
         // 영문만
-        assertThatThrownBy(() -> PasswordValidator.validate("abcdefgh"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("abcdefgh"))
                 .isInstanceOf(InvalidPasswordFormatException.class);
         // 숫자만
-        assertThatThrownBy(() -> PasswordValidator.validate("12345678"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("12345678"))
                 .isInstanceOf(InvalidPasswordFormatException.class);
         // 특수문자만
-        assertThatThrownBy(() -> PasswordValidator.validate("!@#$%^&*"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("!@#$%^&*"))
                 .isInstanceOf(InvalidPasswordFormatException.class);
     }
 
     @Test
     @DisplayName("같은 문자가 3번 이상 연속되면 InvalidPasswordFormatException이 발생한다.")
     void invalidPasswordRepetition() {
-        assertThatThrownBy(() -> PasswordValidator.validate("aaa12345"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("aaa12345"))
                 .isInstanceOf(InvalidPasswordFormatException.class);
-        assertThatThrownBy(() -> PasswordValidator.validate("11!111abc"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("11!111abc"))
                 .isInstanceOf(InvalidPasswordFormatException.class);
-        assertThatThrownBy(() -> PasswordValidator.validate("abc!!!123"))
+        assertThatThrownBy(() -> PasswordValidator.validatePasswordFormat("abc!!!123"))
                 .isInstanceOf(InvalidPasswordFormatException.class);
     }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-178]


## 👩‍💻 작업 내용
로그인 전 비밀번호 찾는 로직을 구현했습니다. 엄연히 DB에는 해싱된 비밀번호가 저장되어 있어, 원문의 비밀번호를 찾을 수 없기 때문에 비밀번호 찾기이지만, 비밀번호를 변경하는 로직과 동일합니다.
<!-- 작업 내용을 적어주세요 -->

## 📸 스크린 샷 (선택)
<img width="665" alt="image" src="https://github.com/user-attachments/assets/cb018abc-b6ce-412e-8dbe-41d3854690d9" />
