### PR TITLE
[EDMT-] refreshToken 검증 시 Bearer 파싱 로직 제외

### DIFF
--- a/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/exception/code/AuthErrorCode.java
@@ -18,13 +18,13 @@ public enum AuthErrorCode implements ErrorCode {
 
     // 401 Unauthorized,
     INVALID_ACCESS_TOKEN_VALUE("EDMT-4010101", "유효하지 않은 엑세스 토큰입니다."),
-    INVALID_REFRESH_TOKEN_VALUE("EDMT-4010107", "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_TOKEN("EDMT-4010102", "이미 만료된 토큰입니다."),
     UNAUTHORIZED("EDMT-4010103", "인증되지 않은 사용자입니다."),
     MISSED_TOKEN("EDMT-4010104", "인증 토큰이 누락되었습니다."),
     INVALID_TOKEN_TYPE("EDMT-4010105", "잘못된 유형의 토큰입니다. 요청에는 엑세스 토큰이 필요합니다."),
     INVALID_SIGNATURE_TOKEN("EDMT-4010106", "토큰의 서명이 유효하지 않습니다."),
-    INVALID_PASSWORD("EDMT-4010107", "비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN_VALUE("EDMT-4010107", "유효하지 않은 리프레시 토큰입니다."),
+    INVALID_PASSWORD("EDMT-4010108", "비밀번호가 일치하지 않습니다."),
 
     // 403 Forbidden
     FORBIDDEN("EDMT-4030101", "권한이 부족한 사용자입니다."),

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -10,9 +10,11 @@ import com.edumate.eduserver.member.domain.Member;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -29,14 +31,12 @@ public class TokenService {
     }
 
     public String getMemberUuidFromToken(final String refreshToken) {
-        String prefixRemovedToken = jwtParser.resolveToken(refreshToken);
-        jwtValidator.validateToken(prefixRemovedToken, TokenType.REFRESH);
-        return jwtParser.getMemberUuidFromToken(prefixRemovedToken);
+        jwtValidator.validateToken(refreshToken, TokenType.REFRESH);
+        return jwtParser.getMemberUuidFromToken(refreshToken);
     }
 
     public void checkTokenEquality(final String requestRefreshToken, final String storedRefreshToken) {
-        String prefixRemovedToken = jwtParser.resolveToken(requestRefreshToken);
-        if (!isTokenMatched(prefixRemovedToken, storedRefreshToken)) {
+        if (!isTokenMatched(requestRefreshToken, storedRefreshToken)) {
             throw new MismatchedTokenException(AuthErrorCode.INVALID_REFRESH_TOKEN_VALUE);
         }
     }

--- a/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.edumate.eduserver.auth.exception.MismatchedTokenException;
@@ -54,23 +53,10 @@ class TokenServiceTest {
     }
 
     @Test
-    @DisplayName("refreshToken에서 memberUuid를 정상적으로 추출한다.")
-    void getMemberUuidFromToken() {
-        String refreshToken = "Bearer refresh-token";
-        String resolvedToken = "refresh-token";
-        when(jwtParser.resolveToken(refreshToken)).thenReturn(resolvedToken);
-        doNothing().when(jwtValidator).validateToken(resolvedToken, TokenType.REFRESH);
-        when(jwtParser.getMemberUuidFromToken(resolvedToken)).thenReturn("uuid-1234");
-
-        String uuid = tokenService.getMemberUuidFromToken(refreshToken);
-        assertThat(uuid).isEqualTo("uuid-1234");
-    }
-
-    @Test
     @DisplayName("토큰이 정상적으로 검증된다.")
     void checkTokenEquality() {
         // given
-        String requestRefreshToken = "Bearer refresh-token";
+        String requestRefreshToken = "refresh-token";
         String storedRefreshToken = "refresh-token";
         String resolvedToken = "refresh-token";
 
@@ -79,7 +65,6 @@ class TokenServiceTest {
 
         // when & then
         tokenService.checkTokenEquality(requestRefreshToken, storedRefreshToken);
-        verify(jwtParser).resolveToken(requestRefreshToken);
     }
 
     @Test

--- a/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
@@ -71,7 +71,7 @@ class TokenServiceTest {
     @DisplayName("저장된 토큰과 요청 토큰이 불일치하면 예외가 발생한다.")
     void tokenEqualityMismatch() {
         // given
-        String requestRefreshToken = "Bearer refresh-token";
+        String requestRefreshToken = "refresh-token";
         String storedRefreshToken = "different-refresh-token";
         String resolvedToken = "refresh-token";
 


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-193]


## 👩‍💻 작업 내용
refreshToken 전달 방식은 message Body에서 쿠키로 변경함에 따라 토큰 검증 시 Bearer prefix를 제거하는 로직 삭제
<!-- 작업 내용을 적어주세요 -->

## 📝 리뷰 요청 & 논의하고 싶은 내용
앞으로 꼼꼼히 테스트하고 PR 날리겠슴다..
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

## 📸 스크린 샷 (선택)
<img width="651" alt="image" src="https://github.com/user-attachments/assets/7969ea99-fedc-4fd8-ac06-dcca920cc826" />


[EDMT-193]: https://bbangbbangz.atlassian.net/browse/EDMT-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 토큰 및 비밀번호 오류 코드가 중복되지 않도록 수정되었습니다.
  - 오류 코드의 순서와 값이 일관성 있게 정렬되었습니다.

- **기타**
  - 내부 토큰 처리 방식이 간소화되어, 토큰 검증 및 비교 과정이 개선되었습니다.
  - 테스트 코드에서 토큰 처리 관련 일부 테스트가 제거 및 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->