### PR TITLE
[EDMT-131] 생활기록부 타입 ENUM value명 변경

### DIFF
--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -95,7 +95,8 @@ public class AuthFacade {
         String accessToken = tokenService.generateTokens(member, TokenType.ACCESS);
         String refreshToken = tokenService.generateTokens(member, TokenType.REFRESH);
         memberService.updateRefreshToken(member, refreshToken);
-        issueVerificationCode(member);
+        String authCode = issueVerificationCode(member);
+        eventPublisher.publishEvent(MemberSignedUpEvent.of(member.getEmail(), member.getMemberUuid(), authCode));
         return MemberSignUpResponse.of(accessToken, refreshToken);
     }
 
@@ -114,10 +115,10 @@ public class AuthFacade {
         }
     }
 
-    private void issueVerificationCode(final Member member) {
+    private String issueVerificationCode(final Member member) {
         String code = randomCodeGenerator.generate();
         authService.saveCode(member, code);
-        eventPublisher.publishEvent(MemberSignedUpEvent.of(member.getEmail(), member.getMemberUuid(), code));
+        return code;
     }
 
     @Transactional

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordType.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordType.java
@@ -7,11 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StudentRecordType {
 
-    ABILITY_DETAIL("ABILITY", 1500),
-    BEHAVIOR_OPINION("BEHAVIOR", 1500),
-    CREATIVE_ACTIVITY_CAREER("CREATIVE-CAREER", 1500),
-    CREATIVE_ACTIVITY_AUTONOMY("CREATIVE-AUTONOMY", 1500),
-    CREATIVE_ACTIVITY_CLUB("CREATIVE-CLUB", 1500);
+    ABILITY_DETAIL("SUBJECT", 1500), // 과세특
+    BEHAVIOR_OPINION("BEHAVIOR", 1500), // 행발
+    CREATIVE_ACTIVITY_CAREER("CAREER", 1500), // 진로
+    CREATIVE_ACTIVITY_AUTONOMY("FREE", 1500), // 자율
+    CREATIVE_ACTIVITY_CLUB("CLUB", 1500); // 동아리
 
     private final String value;
     private final int byteCount;

--- a/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/service/TokenServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import com.edumate.eduserver.auth.exception.MismatchedTokenException;
 import com.edumate.eduserver.auth.jwt.JwtGenerator;
-import com.edumate.eduserver.auth.jwt.JwtParser;
 import com.edumate.eduserver.auth.jwt.JwtValidator;
 import com.edumate.eduserver.auth.jwt.TokenType;
 import com.edumate.eduserver.member.domain.Member;
@@ -24,8 +23,7 @@ class TokenServiceTest {
 
     @Mock
     private JwtGenerator jwtGenerator;
-    @Mock
-    private JwtParser jwtParser;
+
     @Mock
     private JwtValidator jwtValidator;
 
@@ -60,7 +58,6 @@ class TokenServiceTest {
         String storedRefreshToken = "refresh-token";
         String resolvedToken = "refresh-token";
 
-        when(jwtParser.resolveToken(requestRefreshToken)).thenReturn(resolvedToken);
         doNothing().when(jwtValidator).validateToken(resolvedToken, TokenType.REFRESH);
 
         // when & then
@@ -75,7 +72,6 @@ class TokenServiceTest {
         String storedRefreshToken = "different-refresh-token";
         String resolvedToken = "refresh-token";
 
-        when(jwtParser.resolveToken(requestRefreshToken)).thenReturn(resolvedToken);
         doNothing().when(jwtValidator).validateToken(resolvedToken, TokenType.REFRESH);
 
         // when & then

--- a/src/test/java/com/edumate/eduserver/common/StudentRecordTypeConverterTest.java
+++ b/src/test/java/com/edumate/eduserver/common/StudentRecordTypeConverterTest.java
@@ -16,7 +16,7 @@ class StudentRecordTypeConverterTest {
     @Test
     @DisplayName("정상적인 값은 StudentRecordType으로 변환된다")
     void convert_validValue() {
-        assertThat(converter.convert("ability")).isEqualTo(StudentRecordType.ABILITY_DETAIL);
+        assertThat(converter.convert("subject")).isEqualTo(StudentRecordType.ABILITY_DETAIL);
         assertThat(converter.convert("behavior")).isEqualTo(StudentRecordType.BEHAVIOR_OPINION);
     }
 


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-131]


## 👩‍💻 작업 내용
프론트와 변수명 통일을 위해 수정했습니다.
<!-- 작업 내용을 적어주세요 -->



[EDMT-131]: https://bbangbbangz.atlassian.net/browse/EDMT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 학생부 유형 관련 문자열 값이 일부 변경되어, "ABILITY"가 "SUBJECT" 등으로 수정되었습니다.
- **테스트**
  - 학생부 유형 변환 테스트의 입력값이 최신 문자열 값에 맞게 수정되었습니다.
  - 토큰 서비스 테스트에서 불필요한 모의 객체(JwtParser) 사용이 제거되어 테스트가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->