### PR TITLE
[EDMT-211] 비밀번호 변경 전 이메일 주소 전송 API 구현

### DIFF
--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -67,24 +67,40 @@ operation::auth/logout-success[snippets="http-request,request-headers,http-respo
 operation::auth/reissue-success[snippets="http-request,request-cookies,http-response,response-fields,response-cookies"]
 
 ==== 실패: 리프레시 토큰 만료
+
 operation::auth/reissue-fail/expired-token[snippets="http-request,http-response"]
 
 ==== 실패: 리프레시 토큰이 일치하지 않음
+
 operation::auth/reissue-fail/invalid-token[snippets="http-request,http-response"]
+
+=== 로그인 전 비밀번호 찾기(이메일 주소 전송)
+
+==== 성공
+
+operation::auth/find-password-success[snippets="http-request,request-fields,http-response,response-fields"]
+
+=== 실패: 유효하지 않은 이메일 형식
+operation::auth/find-password-fail/invalid-email-format[snippets="http-request,http-response"]
+
+==== 실패: 가입되지 않은 이메일
+
+operation::auth/find-password-fail/member-not-found[snippets="http-request,http-response"]
 
 === 로그인 전 비밀번호 찾기(변경)
 
 ==== 성공
+
 operation::auth/update-password-success[snippets="http-request,request-fields,http-response,response-fields"]
 
 ==== 실패: 유효하지 않은 비밀번호 형식
+
 operation::auth/update-password-fail/invalid-password-format[snippets="http-request,http-response"]
 
 ==== 실패: 유효하지 않은 비밀번호 길이
+
 operation::auth/update-password-fail/invalid-password-length[snippets="http-request,http-response"]
 
-==== 실패: 사용자를 찾을 수 없음
-operation::auth/update-password-fail/member-not-found[snippets="http-request,http-response"]
-
 ==== 실패: 이전과 동일한 비밀번호
+
 operation::auth/update-password-fail/password-repetition[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.edumate.eduserver.auth.controller;
 
 import com.edumate.eduserver.auth.controller.request.MemberLoginRequest;
 import com.edumate.eduserver.auth.controller.request.MemberSignUpRequest;
+import com.edumate.eduserver.auth.controller.request.PasswordFindRequest;
 import com.edumate.eduserver.auth.controller.request.UpdatePasswordRequest;
 import com.edumate.eduserver.auth.facade.AuthFacade;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
@@ -82,6 +83,12 @@ public class AuthController {
     @PatchMapping("/password")
     public ApiResponse<Void> updatePassword(@RequestBody @Valid final UpdatePasswordRequest request) {
         authFacade.updatePassword(request.email().strip(), request.password().strip());
+        return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
+    @PostMapping("/find-password")
+    public ApiResponse<Void> findPassword(@RequestBody @Valid final PasswordFindRequest request) {
+        authFacade.findPassword(request.email().strip());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/controller/request/PasswordFindRequest.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/request/PasswordFindRequest.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.auth.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record PasswordFindRequest(
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        @NotNull(message = "이메일 주소를 입력해주세요.")
+        String email
+) {
+}

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -134,4 +134,8 @@ public class AuthFacade {
     private boolean isPasswordMatched(final String rawPassword, final String encodedPassword) {
         return passwordEncoder.matches(rawPassword, encodedPassword);
     }
+
+    public void findPassword(final String email) {
+        memberService.checkExistedEmail(email);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
             "/api/v1/auth/reissue",
             "/api/v1/auth/password",
             "/api/v1/auth/verify-email",
+            "/api/v1/auth/find-password",
             "/actuator/health"
     };
     private static final String[] BUSINESS_WHITE_LIST = {

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -81,7 +81,7 @@ public class MemberService {
     }
 
     public void checkExistedEmail(final String email) {
-        if (memberRepository.existsByEmailAndIsDeleted(email, NOT_DELETED)) {
+        if (!memberRepository.existsByEmailAndIsDeleted(email, NOT_DELETED)) {
             throw new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND);
         }
     }

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -80,6 +80,12 @@ public class MemberService {
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
+    public void checkExistedEmail(final String email) {
+        if (memberRepository.existsByEmailAndIsDeleted(email, NOT_DELETED)) {
+            throw new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
     public boolean isAdmin(final Member member) {
         return member.getRole() == Role.ADMIN;
     }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-211]


## 👩‍💻 작업 내용
비밀번호 변경 전, 회원가입된 회원인지를 판별하기 위한 이메일 주소 전송받고 검증하는 로직을 구현합니다


[EDMT-211]: https://bbangbbangz.atlassian.net/browse/EDMT-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이메일을 통한 비밀번호 찾기(로그인 전) 기능이 추가되었습니다.

- **문서**
  - 비밀번호 찾기(이메일 주소 전송) API 사용법 및 예시가 문서에 추가되었습니다.

- **버그 수정**
  - 비밀번호 변경 실패 시의 일부 오류 응답 예시가 문서에서 정리되었습니다.

- **테스트**
  - 이메일로 비밀번호 찾기 성공/실패/유효하지 않은 이메일 형식에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->