### PR TITLE
[EDMT-222] 공지사항 수정 및 삭제 API 구현

### DIFF
--- a/src/docs/asciidoc/api/notice.adoc
+++ b/src/docs/asciidoc/api/notice.adoc
@@ -25,3 +25,23 @@ operation::notice/create-success[snippets="request-fields,http-request,http-resp
 ==== 실패: 작성할 수 없는 카테고리(ALL)
 
 operation::notice/create-fail-invalid-category[snippets="request-fields,http-request,http-response"]
+
+=== 공지사항 수정
+
+==== 성공
+
+operation::notice/update-success[snippets="path-parameters,request-fields,http-request,http-response"]
+
+==== 실패: 해당 공지사항이 존재하지 않음
+
+operation::notice/get-one-fail-not-found[snippets="http-request,http-response"]
+
+=== 공지사항 삭제
+
+==== 성공
+
+operation::notice/delete-success[snippets="path-parameters,http-request,http-response"]
+
+==== 실패: 해당 공지사항이 존재하지 않음
+
+operation::notice/get-one-fail-not-found[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/auth/domain/AuthorizationCode.java
+++ b/src/main/java/com/edumate/eduserver/auth/domain/AuthorizationCode.java
@@ -47,7 +47,7 @@ public class AuthorizationCode {
 
     private static final int MINUTES_TO_EXPIRE = 10;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private AuthorizationCode(final Member member, final String authorizationCode, final LocalDateTime createdAt,
                               final LocalDateTime expiredAt, final AuthorizeStatus status) {
         this.member = member;

--- a/src/main/java/com/edumate/eduserver/common/entity/BaseEntity.java
+++ b/src/main/java/com/edumate/eduserver/common/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.edumate.eduserver;
+package com.edumate.eduserver.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -69,7 +69,7 @@ public class Member extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Member(final Subject subject, final String email, final String password, final String nickname,
                    final School school, final Role role, final LocalDateTime verifiedAt, final boolean isDeleted,
                    final LocalDateTime deletedAt, final String memberUuid) {

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -1,6 +1,6 @@
 package com.edumate.eduserver.member.domain;
 
-import com.edumate.eduserver.BaseEntity;
+import com.edumate.eduserver.common.entity.BaseEntity;
 import com.edumate.eduserver.subject.domain.Subject;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/edumate/eduserver/member/domain/NicknameBannedWord.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/NicknameBannedWord.java
@@ -1,6 +1,6 @@
 package com.edumate.eduserver.member.domain;
 
-import com.edumate.eduserver.BaseEntity;
+import com.edumate.eduserver.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/edumate/eduserver/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/edumate/eduserver/notice/controller/AdminNoticeController.java
@@ -8,6 +8,7 @@ import com.edumate.eduserver.notice.domain.NoticeCategory;
 import com.edumate.eduserver.notice.facade.NoticeFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +39,14 @@ public class AdminNoticeController {
     ) {
         NoticeCategory category = NoticeCategory.fromId(request.categoryId());
         noticeFacade.updateNotice(noticeId, category, request.title(), request.content());
+        return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public ApiResponse<Void> deleteNotice(
+            @PathVariable final long noticeId
+    ) {
+        noticeFacade.deleteNotice(noticeId);
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/edumate/eduserver/notice/controller/AdminNoticeController.java
@@ -3,10 +3,13 @@ package com.edumate.eduserver.notice.controller;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import com.edumate.eduserver.notice.controller.request.NoticeCreateRequest;
+import com.edumate.eduserver.notice.controller.request.NoticeUpdateRequest;
 import com.edumate.eduserver.notice.domain.NoticeCategory;
 import com.edumate.eduserver.notice.facade.NoticeFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +28,16 @@ public class AdminNoticeController {
     ) {
         NoticeCategory category = NoticeCategory.fromId(request.categoryId());
         noticeFacade.createNotice(category, request.title(), request.content());
+        return ApiResponse.success(CommonSuccessCode.OK);
+    }
+
+    @PatchMapping("/{noticeId}")
+    public ApiResponse<Void> updateNotice(
+            @RequestBody @Valid final NoticeUpdateRequest request,
+            @PathVariable final long noticeId
+    ) {
+        NoticeCategory category = NoticeCategory.fromId(request.categoryId());
+        noticeFacade.updateNotice(noticeId, category, request.title(), request.content());
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/notice/controller/request/NoticeUpdateRequest.java
+++ b/src/main/java/com/edumate/eduserver/notice/controller/request/NoticeUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.edumate.eduserver.notice.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record NoticeUpdateRequest(
+        @NotNull(message = "카테고리 ID는 필수입니다.")
+        Integer categoryId,
+        @NotNull(message = "제목은 필수입니다.")
+        String title,
+        @NotNull(message = "내용은 필수입니다.")
+        String content
+) {
+    public static NoticeUpdateRequest of(final int categoryId,
+                                         final String title,
+                                         final String content) {
+        return new NoticeUpdateRequest(
+                categoryId,
+                title,
+                content
+        );
+    }
+}

--- a/src/main/java/com/edumate/eduserver/notice/domain/Notice.java
+++ b/src/main/java/com/edumate/eduserver/notice/domain/Notice.java
@@ -1,6 +1,6 @@
 package com.edumate.eduserver.notice.domain;
 
-import com.edumate.eduserver.BaseEntity;
+import com.edumate.eduserver.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/edumate/eduserver/notice/domain/Notice.java
+++ b/src/main/java/com/edumate/eduserver/notice/domain/Notice.java
@@ -13,10 +13,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class Notice extends BaseEntity {
     @Id
     @Column(name = "notice_id")
@@ -57,5 +59,10 @@ public class Notice extends BaseEntity {
         this.category = category;
         this.title = title;
         this.content = content;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/edumate/eduserver/notice/domain/Notice.java
+++ b/src/main/java/com/edumate/eduserver/notice/domain/Notice.java
@@ -52,4 +52,10 @@ public class Notice extends BaseEntity {
                 .content(content)
                 .build();
     }
+
+    public void update(NoticeCategory category, String title, String content) {
+        this.category = category;
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/edumate/eduserver/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/edumate/eduserver/notice/facade/NoticeFacade.java
@@ -51,4 +51,9 @@ public class NoticeFacade {
     public void updateNotice(final long noticeId, final NoticeCategory category, final String title, final String content) {
         noticeService.updateNotice(noticeId, category, title, content);
     }
+
+    @Transactional
+    public void deleteNotice(long noticeId) {
+        noticeService.deleteNotice(noticeId);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/edumate/eduserver/notice/facade/NoticeFacade.java
@@ -46,4 +46,9 @@ public class NoticeFacade {
     public void createNotice(final NoticeCategory category, final String title, final String content) {
         noticeService.createNotice(category, title, content);
     }
+
+    @Transactional
+    public void updateNotice(final long noticeId, final NoticeCategory category, final String title, final String content) {
+        noticeService.updateNotice(noticeId, category, title, content);
+    }
 }

--- a/src/main/java/com/edumate/eduserver/notice/service/NoticeService.java
+++ b/src/main/java/com/edumate/eduserver/notice/service/NoticeService.java
@@ -49,6 +49,12 @@ public class NoticeService {
         notice.update(category, title, content);
     }
 
+    @Transactional
+    public void deleteNotice(final long noticeId) {
+        Notice notice = getNotice(noticeId);
+        notice.delete();
+    }
+
     private void validateCategory(final NoticeCategory category) {
         if (category == null || !category.isCreatable()) {
             throw new InvalidNoticeCategoryException(NoticeErrorCode.UNWRITABLE_NOTICE_CATEGORY);

--- a/src/main/java/com/edumate/eduserver/notice/service/NoticeService.java
+++ b/src/main/java/com/edumate/eduserver/notice/service/NoticeService.java
@@ -42,6 +42,13 @@ public class NoticeService {
         noticeRepository.save(notice);
     }
 
+    @Transactional
+    public void updateNotice(final long noticeId, final NoticeCategory category, final String title, final String content) {
+        validateCategory(category);
+        Notice notice = getNotice(noticeId);
+        notice.update(category, title, content);
+    }
+
     private void validateCategory(final NoticeCategory category) {
         if (category == null || !category.isCreatable()) {
             throw new InvalidNoticeCategoryException(NoticeErrorCode.UNWRITABLE_NOTICE_CATEGORY);

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/RecordMetadata.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/RecordMetadata.java
@@ -37,7 +37,7 @@ public class RecordMetadata {
     @Column(nullable = false)
     private String semester;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private RecordMetadata(final Member member, final StudentRecordType studentRecordType, final String semester) {
         this.member = member;
         this.studentRecordType = studentRecordType;

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/RecordPrompt.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/RecordPrompt.java
@@ -30,7 +30,7 @@ public class RecordPrompt {
     @Column(nullable = false)
     private String prompt;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private RecordPrompt(final StudentRecordDetail studentRecordDetail, final String prompt) {
         this.studentRecordDetail = studentRecordDetail;
         this.prompt = prompt;

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
@@ -53,7 +53,7 @@ public class StudentRecordDetail extends BaseEntity {
         this.byteCount = byteCount;
     }
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private StudentRecordDetail(final RecordMetadata recordMetadata, final String studentNumber,
                                 final String studentName, final String description, final int byteCount) {
         this.recordMetadata = recordMetadata;

--- a/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/domain/StudentRecordDetail.java
@@ -1,6 +1,6 @@
 package com.edumate.eduserver.studentrecord.domain;
 
-import com.edumate.eduserver.BaseEntity;
+import com.edumate.eduserver.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/edumate/eduserver/subject/domain/Subject.java
+++ b/src/main/java/com/edumate/eduserver/subject/domain/Subject.java
@@ -23,7 +23,7 @@ public class Subject {
     @Column(nullable = false)
     private String name;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Subject(final String name) {
         this.name = name;
     }

--- a/src/test/java/com/edumate/eduserver/notice/controller/AdminNoticeControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/notice/controller/AdminNoticeControllerTest.java
@@ -3,15 +3,20 @@ package com.edumate.eduserver.notice.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
 import com.edumate.eduserver.notice.controller.request.NoticeCreateRequest;
+import com.edumate.eduserver.notice.controller.request.NoticeUpdateRequest;
 import com.edumate.eduserver.notice.domain.NoticeCategory;
 import com.edumate.eduserver.notice.exception.InvalidNoticeCategoryException;
 import com.edumate.eduserver.notice.exception.code.NoticeErrorCode;
@@ -121,6 +126,74 @@ class AdminNoticeControllerTest extends ControllerTest {
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("공지사항을 성공적으로 수정한다.")
+    void updateNotice_Success() throws Exception {
+        // given
+        long noticeId = 1L;
+        NoticeUpdateRequest request = new NoticeUpdateRequest(
+                NoticeCategory.NOTICE.getId(),
+                "수정된 제목",
+                "수정된 내용"
+        );
+
+        doNothing().when(noticeFacade).updateNotice(any(Long.class), any(), any(), any());
+
+        // when & then
+        mockMvc.perform(patch(BASE_URL + "/{noticeId}", noticeId)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .contentType("application/json")
+                        .content(toJson(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(
+                        BASE_DOMAIN_PACKAGE + "update-success",
+                        pathParameters(
+                                parameterWithName("noticeId").description("공지사항 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("categoryId").description("공지사항 카테고리 ID"),
+                                fieldWithPath("title").description("공지사항 제목"),
+                                fieldWithPath("content").description("공지사항 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("공지사항을 성공적으로 삭제한다.")
+    void deleteNotice_Success() throws Exception {
+        // given
+        long noticeId = 1L;
+
+        doNothing().when(noticeFacade).deleteNotice(noticeId);
+
+        // when & then
+        mockMvc.perform(delete(BASE_URL + "/{noticeId}", noticeId)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(
+                        BASE_DOMAIN_PACKAGE + "delete-success",
+                        pathParameters(
+                                parameterWithName("noticeId").description("공지사항 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
                         )
                 ));
     }

--- a/src/test/java/com/edumate/eduserver/notice/facade/NoticeFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/notice/facade/NoticeFacadeTest.java
@@ -117,4 +117,37 @@ class NoticeFacadeTest {
         // then
         verify(noticeService).createNotice(category, title, content);
     }
+
+    @Test
+    @DisplayName("공지사항 수정이 정상 동작한다.")
+    void updateNotice_Success() {
+        // given
+        long noticeId = 1L;
+        NoticeCategory category = NoticeCategory.NOTICE;
+        String title = "수정된 제목";
+        String content = "수정된 내용";
+
+        willDoNothing().given(noticeService).updateNotice(noticeId, category, title, content);
+
+        // when
+        noticeFacade.updateNotice(noticeId, category, title, content);
+
+        // then
+        verify(noticeService).updateNotice(noticeId, category, title, content);
+    }
+
+    @Test
+    @DisplayName("공지사항 삭제가 정상 동작한다.")
+    void deleteNotice_Success() {
+        // given
+        long noticeId = 1L;
+        willDoNothing().given(noticeService).deleteNotice(noticeId);
+
+        // when
+        noticeFacade.deleteNotice(noticeId);
+
+        // then
+        verify(noticeService).deleteNotice(noticeId);
+    }
+
 }

--- a/src/test/java/com/edumate/eduserver/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/notice/service/NoticeServiceTest.java
@@ -11,6 +11,7 @@ import com.edumate.eduserver.notice.exception.code.NoticeErrorCode;
 import com.edumate.eduserver.notice.repository.NoticeRepository;
 import com.edumate.eduserver.util.ServiceTest;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -128,5 +129,39 @@ class NoticeServiceTest extends ServiceTest {
         assertThatThrownBy(() -> noticeService.createNotice(invalidCategory, title, content))
                 .isInstanceOf(InvalidNoticeCategoryException.class)
                 .hasMessage(NoticeErrorCode.UNWRITABLE_NOTICE_CATEGORY.getMessage());
+    }
+
+    @Test
+    @DisplayName("공지사항 수정을 정상적으로 수행한다.")
+    void updateNotice_Success() {
+        // given
+        Notice notice = noticeRepository.save(Notice.create(NoticeCategory.NOTICE, "기존 제목", "기존 내용"));
+        String updatedTitle = "수정된 제목";
+        String updatedContent = "수정된 내용";
+        NoticeCategory updatedCategory = NoticeCategory.EVENT;
+
+        // when
+        noticeService.updateNotice(notice.getId(), updatedCategory, updatedTitle, updatedContent);
+
+        // then
+        Notice updated = noticeRepository.findById(notice.getId()).orElseThrow();
+        assertThat(updated.getTitle()).isEqualTo(updatedTitle);
+        assertThat(updated.getContent()).isEqualTo(updatedContent);
+        assertThat(updated.getCategory()).isEqualTo(updatedCategory);
+    }
+
+    @Test
+    @DisplayName("공지사항 삭제를 정상적으로 수행한다.")
+    void deleteNotice_Success() {
+        // given
+        Notice notice = noticeRepository.save(Notice.create(NoticeCategory.NOTICE, "삭제할 공지", "내용"));
+        long id = notice.getId();
+
+        // when
+        noticeService.deleteNotice(id);
+
+        // then
+        Optional<Notice> deleteNotice = noticeRepository.findById(id);
+        assertThat(deleteNotice).isEmpty();
     }
 }


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-222]


## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
공지사항 한 개를 수정하는 API와 삭제하는 API를 구현했습니다.


[EDMT-222]: https://bbangbbangz.atlassian.net/browse/EDMT-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 공지사항의 수정 및 삭제 기능이 관리자 페이지에 추가되었습니다.
- **Documentation**
    - 공지사항 API 문서에 수정 및 삭제 관련 내용이 추가되었습니다.
- **Tests**
    - 공지사항 수정 및 삭제 기능에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->