### PR TITLE
[EDMT-224] 로그인, 토큰 재발급 시 isAdmin 필드 추가

### DIFF
--- a/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edumate/eduserver/auth/controller/AuthController.java
@@ -9,7 +9,7 @@ import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.common.ApiResponse;
-import com.edumate.eduserver.common.RefreshTokenCookieHandler;
+import com.edumate.eduserver.common.CookieHandler;
 import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthFacade authFacade;
-    private final RefreshTokenCookieHandler refreshTokenCookieHandler;
+    private final CookieHandler cookieHandler;
 
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
@@ -52,7 +52,7 @@ public class AuthController {
                                                     final HttpServletResponse response) {
         MemberSignUpResponse signUpResponse = authFacade.signUp(request.email().strip(), request.password().strip(),
                 request.subject().strip(), request.school().strip());
-        refreshTokenCookieHandler.setRefreshTokenCookie(response, signUpResponse.refreshToken());
+        cookieHandler.setRefreshTokenCookie(response, signUpResponse.refreshToken());
         return ApiResponse.success(CommonSuccessCode.OK, signUpResponse);
     }
 
@@ -60,14 +60,14 @@ public class AuthController {
     public ApiResponse<MemberLoginResponse> login(@RequestBody @Valid final MemberLoginRequest request,
                                                   final HttpServletResponse response) {
         MemberLoginResponse loginResponse = authFacade.login(request.email().strip(), request.password().strip());
-        refreshTokenCookieHandler.setRefreshTokenCookie(response, loginResponse.refreshToken());
+        cookieHandler.setRefreshTokenCookie(response, loginResponse.refreshToken());
         return ApiResponse.success(CommonSuccessCode.OK, loginResponse);
     }
 
     @PostMapping("/logout")
     public ApiResponse<Void> logout(@MemberId final long memberId, final HttpServletResponse response) {
         authFacade.logout(memberId);
-        refreshTokenCookieHandler.clearRefreshTokenCookie(response);
+        cookieHandler.clearRefreshTokenCookie(response);
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
@@ -76,7 +76,7 @@ public class AuthController {
             @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME) final String refreshToken,
             final HttpServletResponse response) {
         MemberReissueResponse reissueResponse = authFacade.reissue(refreshToken.strip());
-        refreshTokenCookieHandler.setRefreshTokenCookie(response, reissueResponse.refreshToken());
+        cookieHandler.setRefreshTokenCookie(response, reissueResponse.refreshToken());
         return ApiResponse.success(CommonSuccessCode.OK, reissueResponse);
     }
 

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -80,7 +80,8 @@ public class AuthFacade {
             String newAccessToken = tokenService.generateTokens(member, TokenType.ACCESS);
             String newRefreshToken = tokenService.generateTokens(member, TokenType.REFRESH);
             memberService.updateRefreshToken(member, newRefreshToken);
-            return MemberReissueResponse.of(newAccessToken, newRefreshToken);
+            boolean isAdmin = memberService.isAdmin(member);
+            return MemberReissueResponse.of(newAccessToken, newRefreshToken, isAdmin);
         } catch (Exception e) {
             logout(member.getId());
             throw e;
@@ -88,7 +89,8 @@ public class AuthFacade {
     }
 
     @Transactional
-    public MemberSignUpResponse signUp(final String email, final String password, final String subjectName, final String school) {
+    public MemberSignUpResponse signUp(final String email, final String password, final String subjectName,
+                                       final String school) {
         checkPreconditions(email, password);
         Subject subject = subjectService.getSubjectByName(subjectName);
         Member member = createMember(email, password, subject, school);

--- a/src/main/java/com/edumate/eduserver/auth/facade/response/MemberReissueResponse.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/response/MemberReissueResponse.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public record MemberReissueResponse(
         String accessToken,
         @JsonIgnore
-        String refreshToken
+        String refreshToken,
+        boolean isAdmin
 ) {
-    public static MemberReissueResponse of(final String accessToken, final String refreshToken) {
-        return new MemberReissueResponse(accessToken, refreshToken);
+    public static MemberReissueResponse of(final String accessToken, final String refreshToken, final boolean isAdmin) {
+        return new MemberReissueResponse(accessToken, refreshToken, isAdmin);
     }
 }

--- a/src/main/java/com/edumate/eduserver/auth/facade/response/MemberSignUpResponse.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/response/MemberSignUpResponse.java
@@ -5,9 +5,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public record MemberSignUpResponse(
         String accessToken,
         @JsonIgnore
-        String refreshToken
+        String refreshToken,
+        boolean isAdmin
 ) {
+
+    private static final boolean DEFAULT_IS_ADMIN = false;
+
     public static MemberSignUpResponse of(final String accessToken, final String refreshToken) {
-        return new MemberSignUpResponse(accessToken, refreshToken);
+        return new MemberSignUpResponse(accessToken, refreshToken, DEFAULT_IS_ADMIN);
     }
 }

--- a/src/main/java/com/edumate/eduserver/common/CookieHandler.java
+++ b/src/main/java/com/edumate/eduserver/common/CookieHandler.java
@@ -5,7 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 
 @Component
-public class RefreshTokenCookieHandler {
+public class CookieHandler {
 
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -185,7 +185,7 @@ class AuthControllerTest extends ControllerTest {
         // given
         MemberSignUpRequest request = new MemberSignUpRequest(
                 "test@email.com", "password123", "수학", "middle");
-        MemberSignUpResponse response = new MemberSignUpResponse("access-token", "refresh-token");
+        MemberSignUpResponse response = new MemberSignUpResponse("access-token", "refresh-token", false);
 
         when(authFacade.signUp(
                 eq(request.email().trim()),
@@ -223,7 +223,8 @@ class AuthControllerTest extends ControllerTest {
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data.accessToken").description("액세스 토큰")
+                                fieldWithPath("data.accessToken").description("액세스 토큰"),
+                                fieldWithPath("data.isAdmin").description("관리자 여부")
                         ),
                         responseCookies(
                                 cookieWithName("refreshToken").description("리프레시 토큰")
@@ -484,7 +485,7 @@ class AuthControllerTest extends ControllerTest {
     @Test
     @DisplayName("토큰 재발급에 성공한다.")
     void reissueSuccess() throws Exception {
-        MemberReissueResponse response = new MemberReissueResponse("new-access-token", "new-refresh-token");
+        MemberReissueResponse response = new MemberReissueResponse("new-access-token", "new-refresh-token", false);
 
         doAnswer(invocation -> {
             HttpServletResponse resp = invocation.getArgument(0);
@@ -514,7 +515,8 @@ class AuthControllerTest extends ControllerTest {
                                 fieldWithPath("status").description("HTTP 상태 코드"),
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data.accessToken").description("새로운 액세스 토큰")
+                                fieldWithPath("data.accessToken").description("새로운 액세스 토큰"),
+                                fieldWithPath("data.isAdmin").description("관리자 여부")
                         ),
                         responseCookies(
                                 cookieWithName("refreshToken").description("새로운 리프레시 토큰")

--- a/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/controller/AuthControllerTest.java
@@ -44,7 +44,7 @@ import com.edumate.eduserver.auth.facade.AuthFacade;
 import com.edumate.eduserver.auth.facade.response.MemberLoginResponse;
 import com.edumate.eduserver.auth.facade.response.MemberReissueResponse;
 import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
-import com.edumate.eduserver.common.RefreshTokenCookieHandler;
+import com.edumate.eduserver.common.CookieHandler;
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
 import com.edumate.eduserver.member.exception.MemberNotFoundException;
 import com.edumate.eduserver.member.exception.code.MemberErrorCode;
@@ -65,7 +65,7 @@ class AuthControllerTest extends ControllerTest {
     @MockitoBean
     private AuthFacade authFacade;
     @MockitoBean
-    private RefreshTokenCookieHandler refreshTokenCookieHandler;
+    private CookieHandler cookieHandler;
 
     private static final String BASE_URL = "/api/v1/auth";
     private final String BASE_DOMAIN_PACKAGE = "auth/";
@@ -198,7 +198,7 @@ class AuthControllerTest extends ControllerTest {
             HttpServletResponse resp = invocation.getArgument(0);
             resp.addCookie(new Cookie("refreshToken", "mock-refresh-token"));
             return null;
-        }).when(refreshTokenCookieHandler).setRefreshTokenCookie(any(HttpServletResponse.class), anyString());
+        }).when(cookieHandler).setRefreshTokenCookie(any(HttpServletResponse.class), anyString());
 
         // when & then
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/signup")
@@ -368,7 +368,7 @@ class AuthControllerTest extends ControllerTest {
             HttpServletResponse resp = invocation.getArgument(0);
             resp.addCookie(new Cookie("refreshToken", "mock-refresh-token"));
             return null;
-        }).when(refreshTokenCookieHandler).setRefreshTokenCookie(any(HttpServletResponse.class), anyString());
+        }).when(cookieHandler).setRefreshTokenCookie(any(HttpServletResponse.class), anyString());
 
         mockMvc.perform(RestDocumentationRequestBuilders.post(BASE_URL + "/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -492,7 +492,7 @@ class AuthControllerTest extends ControllerTest {
             Cookie cookie = new Cookie("refreshToken", "new-refresh-token");
             resp.addCookie(cookie);
             return null;
-        }).when(refreshTokenCookieHandler)
+        }).when(cookieHandler)
                 .setRefreshTokenCookie(any(HttpServletResponse.class), eq("new-refresh-token"));
 
         doReturn(response).when(authFacade).reissue(anyString());


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-224]


## 👩‍💻 작업 내용
isAdmin 필드를 추가했습니다.

## 📸 스크린 샷 (선택)
<img width="697" alt="image" src="https://github.com/user-attachments/assets/9329060f-d1fb-4ce1-b641-4ab408041170" />


[EDMT-224]: https://bbangbbangz.atlassian.net/browse/EDMT-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 가입 및 토큰 재발급 응답에 관리자 여부(isAdmin) 정보가 추가되었습니다.

* **문서화**
  * 회원 가입 및 토큰 재발급 API 문서에 isAdmin 필드가 반영되었습니다.

* **테스트**
  * 관리자 여부 필드 추가에 따른 테스트 코드 및 API 문서 검증이 업데이트되었습니다.

* **기타**
  * 쿠키 처리 핸들러 명칭이 RefreshTokenCookieHandler에서 CookieHandler로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->