### PR TITLE
[EDMT-233] MissingRequestCookieException을 전역 예외 처리기에 추가

### DIFF
--- a/src/main/java/com/edumate/eduserver/auth/jwt/JwtValidator.java
+++ b/src/main/java/com/edumate/eduserver/auth/jwt/JwtValidator.java
@@ -37,7 +37,7 @@ public class JwtValidator {
         } catch (SignatureException e) {
             throw new InvalidSignatureTokenException(AuthErrorCode.INVALID_SIGNATURE_TOKEN);
         } catch (IllegalTokenException | IllegalTokenTypeException e) {
-            throw e;
+            throw new IllegalTokenException(AuthErrorCode.INVALID_ACCESS_TOKEN_VALUE);
         } catch (Exception e) {
             log.error("Token validation failed: {}", e.getMessage());
             throw e;

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -39,6 +39,10 @@ public class TokenService {
     }
 
     private boolean isTokenMatched(final String requestRefreshToken, final String storedRefreshToken) {
+        if (requestRefreshToken == null || storedRefreshToken == null) {
+            return false;
+        }
+
         return MessageDigest.isEqual(
                 storedRefreshToken.getBytes(StandardCharsets.UTF_8),
                 requestRefreshToken.getBytes(StandardCharsets.UTF_8)

--- a/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/TokenService.java
@@ -12,11 +12,9 @@ import java.security.MessageDigest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TokenService {
 
@@ -24,7 +22,6 @@ public class TokenService {
     private final JwtParser jwtParser;
     private final JwtValidator jwtValidator;
 
-    @Transactional
     public String generateTokens(final Member member, final TokenType tokenType) {
         String memberUuid = member.getMemberUuid();
         return jwtGenerator.generateToken(memberUuid, tokenType);

--- a/src/main/java/com/edumate/eduserver/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/edumate/eduserver/common/advice/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -38,6 +39,12 @@ public class GlobalExceptionHandler {
         return ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), "EDMT-4002", message);
     }
 
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ApiResponse<Void> handleMissingRequestCookieException(final MissingRequestCookieException e) {
+        log.warn("Missing Request Cookie: {}", e.getMessage());
+        return ApiResponse.fail(HttpStatus.UNAUTHORIZED.value(), "EDMT-4001", e.getMessage());
+    }
+
     @ExceptionHandler(SdkException.class)
     public ApiResponse<Void> handleSdkException(final SdkException e) {
         log.error("AWS SDK Exception: {}", getDeepCause(e).getMessage(), e);
@@ -45,8 +52,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ApiResponse<Void> handleUnexpectedException(final Exception e) {
-        log.error("Unhandled Exception: {}", getDeepCause(e).getMessage(), e);
+    public ApiResponse<Void> handleUnexpectedException(Exception e) {
+        e = (Exception) getDeepCause(e);
+        log.error("Unhandled Exception: {}", e.getMessage(), e);
         return ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR.value(), "EDMT-500", e.getMessage());
     }
 

--- a/src/test/java/com/edumate/eduserver/auth/security/jwt/JwtValidatorTest.java
+++ b/src/test/java/com/edumate/eduserver/auth/security/jwt/JwtValidatorTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.edumate.eduserver.auth.exception.ExpiredTokenException;
-import com.edumate.eduserver.auth.exception.IllegalTokenTypeException;
+import com.edumate.eduserver.auth.exception.IllegalTokenException;
 import com.edumate.eduserver.auth.exception.InvalidSignatureTokenException;
 import com.edumate.eduserver.auth.jwt.JwtGenerator;
 import com.edumate.eduserver.auth.jwt.JwtProperties;
@@ -59,7 +59,7 @@ class JwtValidatorTest {
 
         // when & then
         assertThatThrownBy(() -> jwtValidator.validateToken(token, TokenType.ACCESS))
-                .isInstanceOf(IllegalTokenTypeException.class);
+                .isInstanceOf(IllegalTokenException.class);
     }
 
     @Test


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-233]


## 👩‍💻 작업 내용
쿠키에 refreshToken 값이 null일 때, 발생하는 MissingRequestCookieException을 전역 예외처리기에서 처리하지 않아 발생하는 500에러를 해결하였습니다.


[EDMT-233]: https://bbangbbangz.atlassian.net/browse/EDMT-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 토큰 검증 과정에서 발생하는 특정 예외 처리 방식이 개선되었습니다.
  * 토큰 비교 시 입력값이 null인 경우를 안전하게 처리하도록 수정되었습니다.

* **신규 기능**
  * 쿠키가 누락된 요청에 대해 401 오류와 함께 명확한 에러 메시지가 반환됩니다.

* **기타 개선**
  * 예외 발생 시 근본 원인을 더 정확하게 로그에 남기고 응답에 반영하도록 예외 처리 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->