### PR TITLE
[EDMT-254] 학기 정보가 생성 된 후에도 bulk 추가가 가능하도록 수정

### DIFF
--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -58,7 +58,7 @@ public class StudentRecordFacade {
     public void createStudentRecords(final long memberId, final StudentRecordType recordType, final String semester,
                                      final List<StudentRecordInfo> studentRecordInfos) {
         Member member = memberService.getMemberById(memberId);
-        RecordMetadata studentRecord = studentRecordService.createSemesterRecord(member, recordType, semester);
+        RecordMetadata studentRecord = studentRecordService.createOrGetSemesterRecord(member, recordType, semester);
         studentRecordService.createStudentRecords(studentRecord, studentRecordInfos);
     }
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -111,7 +111,7 @@ class StudentRecordFacadeTest {
         RecordMetadata mockRecord = mock(RecordMetadata.class);
 
         given(memberService.getMemberById(memberId)).willReturn(mockMember);
-        given(studentRecordService.createSemesterRecord(mockMember, type, semester)).willReturn(mockRecord);
+        given(studentRecordService.createOrGetSemesterRecord(mockMember, type, semester)).willReturn(mockRecord);
         willDoNothing().given(studentRecordService).createStudentRecords(mockRecord, studentRecordInfos);
 
         // when
@@ -119,7 +119,7 @@ class StudentRecordFacadeTest {
 
         // then
         verify(memberService).getMemberById(memberId);
-        verify(studentRecordService).createSemesterRecord(mockMember, type, semester);
+        verify(studentRecordService).createOrGetSemesterRecord(mockMember, type, semester);
         verify(studentRecordService).createStudentRecords(mockRecord, studentRecordInfos);
     }
 

--- a/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
@@ -205,7 +205,7 @@ class StudentRecordServiceTest extends ServiceTest {
         StudentRecordType recordType = StudentRecordType.BEHAVIOR_OPINION;
         String semester = "2025-2";
 
-        RecordMetadata recordMetadata = studentRecordService.createSemesterRecord(
+        RecordMetadata recordMetadata = studentRecordService.createOrGetSemesterRecord(
                 defaultTeacher, recordType, semester);
 
         List<StudentRecordInfo> studentRecordInfos = List.of(


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-254]

## 👩‍💻 작업 내용
기획 변경으로, 학기 정보가 생성 된 후에도 bulk 연산이 가능하도록 수정

## 📸 스크린 샷 (선택)
<img width="282" alt="image" src="https://github.com/user-attachments/assets/36531d26-fc55-4fee-8a41-98978be7661a" />


[EDMT-254]: https://bbangbbangz.atlassian.net/browse/EDMT-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 기존 학기 기록이 있을 경우 새로 생성하지 않고 기존 기록을 재사용하도록 동작이 변경되었습니다.

* **테스트**
  * 변경된 학기 기록 생성 및 조회 방식에 맞춰 테스트 코드가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->