### PR TITLE
[EDMT-237] 마이페이지에서 비밀번호 변경 로직 추가

### DIFF
--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -5,3 +5,17 @@
 ==== 성공
 
 operation::member/get-profile-success[snippets="http-request,http-response,response-fields"]
+
+=== 비밀번호 변경
+
+==== 성공
+
+operation::member/update-password-success[snippets="http-request,request-fields,http-response"]
+
+==== 실패: 현재 비밀번호가 일치하지 않음
+
+operation::member/update-password-fail/unmatched-current-password[snippets="http-request,http-response"]
+
+==== 실패: 새 비밀번호가 기존 비밀번호와 일치함
+
+operation::member/update-password-fail/same-password[snippets="http-request,http-response"]

--- a/src/main/java/com/edumate/eduserver/member/controller/MemberController.java
+++ b/src/main/java/com/edumate/eduserver/member/controller/MemberController.java
@@ -3,10 +3,14 @@ package com.edumate.eduserver.member.controller;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
+import com.edumate.eduserver.member.controller.request.PasswordChangeRequest;
 import com.edumate.eduserver.member.facade.MemberFacade;
 import com.edumate.eduserver.member.facade.response.MemberProfileGetResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,9 +22,14 @@ public class MemberController {
     private final MemberFacade memberFacade;
 
     @GetMapping("/profile")
-    public ApiResponse<MemberProfileGetResponse> getMemberProfile(
-            @MemberId final long memberId
-    ) {
+    public ApiResponse<MemberProfileGetResponse> getMemberProfile(@MemberId final long memberId) {
         return ApiResponse.success(CommonSuccessCode.OK, memberFacade.getMemberProfile(memberId));
+    }
+
+    @PatchMapping("/password")
+    public ApiResponse<Void> updatePassword(@MemberId final long memberId,
+                                            @RequestBody @Valid final PasswordChangeRequest request) {
+        memberFacade.updatePassword(memberId, request.currentPassword(), request.newPassword());
+        return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/member/controller/request/PasswordChangeRequest.java
+++ b/src/main/java/com/edumate/eduserver/member/controller/request/PasswordChangeRequest.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.member.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PasswordChangeRequest(
+        @NotNull(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword,
+        @NotNull(message = "새로운 비밀번호를 입력해주세요.")
+        String newPassword
+) {
+}

--- a/src/main/java/com/edumate/eduserver/member/exception/InvalidPasswordException.java
+++ b/src/main/java/com/edumate/eduserver/member/exception/InvalidPasswordException.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.member.exception;
+
+import com.edumate.eduserver.common.exception.BadRequestException;
+import com.edumate.eduserver.member.exception.code.MemberErrorCode;
+
+public class InvalidPasswordException extends BadRequestException {
+
+    public InvalidPasswordException(final MemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/member/exception/PasswordSameAsOldException.java
+++ b/src/main/java/com/edumate/eduserver/member/exception/PasswordSameAsOldException.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.member.exception;
+
+import com.edumate.eduserver.common.exception.BadRequestException;
+import com.edumate.eduserver.member.exception.code.MemberErrorCode;
+
+public class PasswordSameAsOldException extends BadRequestException {
+
+    public PasswordSameAsOldException(final MemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/edumate/eduserver/member/exception/code/MemberErrorCode.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode implements ErrorCode {
     // 400 Bad Request
     INVALID_SCHOOL_TYPE("EDMT-4000401", "입력하신 %s는 유효하지 않습니다. MIDDLE, HIGH 중 하나를 입력해주세요."),
+    INVALID_CURRENT_PASSWORD("EDMT-4000402", "현재 비밀번호가 일치하지 않습니다. 다시 입력해주세요."),
+    SAME_PASSWORD("EDMT-4000403", "새로운 비밀번호는 기존 비밀번호와 같을 수 없습니다."),
 
     // 404 Not Found
     MEMBER_NOT_FOUND("EDMT-4040401", "존재하지 않는 회원입니다. 회원가입을 진행해주세요.");

--- a/src/main/java/com/edumate/eduserver/member/facade/MemberFacade.java
+++ b/src/main/java/com/edumate/eduserver/member/facade/MemberFacade.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberFacade {
 
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional(readOnly = true)
     public MemberProfileGetResponse getMemberProfile(final long memberId) {
         Member member = memberService.getMemberById(memberId);
         return MemberProfileGetResponse.of(
@@ -28,6 +28,7 @@ public class MemberFacade {
         );
     }
 
+    @Transactional
     public void updatePassword(final long memberId, final String currentPassword, final String newPassword) {
         Member member = memberService.getMemberById(memberId);
         PasswordValidator.validatePasswordFormat(newPassword);

--- a/src/main/java/com/edumate/eduserver/member/facade/MemberFacade.java
+++ b/src/main/java/com/edumate/eduserver/member/facade/MemberFacade.java
@@ -1,9 +1,14 @@
 package com.edumate.eduserver.member.facade;
 
+import com.edumate.eduserver.auth.service.PasswordValidator;
 import com.edumate.eduserver.member.domain.Member;
+import com.edumate.eduserver.member.exception.InvalidPasswordException;
+import com.edumate.eduserver.member.exception.PasswordSameAsOldException;
+import com.edumate.eduserver.member.exception.code.MemberErrorCode;
 import com.edumate.eduserver.member.facade.response.MemberProfileGetResponse;
 import com.edumate.eduserver.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberFacade {
 
     private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
 
     public MemberProfileGetResponse getMemberProfile(final long memberId) {
         Member member = memberService.getMemberById(memberId);
@@ -20,5 +26,26 @@ public class MemberFacade {
                 member.getEmail(), member.getSubject().getName(), member.isVerifyTeacher(),
                 member.getSchool().getName(), member.getNickname()
         );
+    }
+
+    public void updatePassword(final long memberId, final String currentPassword, final String newPassword) {
+        Member member = memberService.getMemberById(memberId);
+        PasswordValidator.validatePasswordFormat(newPassword);
+        validatePassword(member, currentPassword, newPassword);
+        member.updatePassword(passwordEncoder.encode(newPassword));
+    }
+
+    private void validatePassword(final Member member, final String currentPassword, final String newPassword) {
+        String savedPassword = member.getPassword();
+        if (!isPasswordMatched(currentPassword, savedPassword)) {
+            throw new InvalidPasswordException(MemberErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+        if (isPasswordMatched(newPassword, savedPassword)) {
+            throw new PasswordSameAsOldException(MemberErrorCode.SAME_PASSWORD);
+        }
+    }
+
+    private boolean isPasswordMatched(final String inputPassword, final String savedPassword) {
+        return passwordEncoder.matches(inputPassword, savedPassword);
     }
 }

--- a/src/test/java/com/edumate/eduserver/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/member/controller/MemberControllerTest.java
@@ -23,7 +23,6 @@ import com.edumate.eduserver.member.exception.code.MemberErrorCode;
 import com.edumate.eduserver.member.facade.MemberFacade;
 import com.edumate.eduserver.member.facade.response.MemberProfileGetResponse;
 import com.edumate.eduserver.util.ControllerTest;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -36,8 +35,6 @@ class MemberControllerTest extends ControllerTest {
 
     @MockitoBean
     private MemberFacade memberFacade;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final String BASE_URL = "/api/v1/users";
     private static final String BASE_DOMAIN_PACKAGE = "member/";


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-237]


## 👩‍💻 작업 내용
마이페이지에서 비밀번호를 변경할 수 있는 기능을 추가합니다.
<!-- 작업 내용을 적어주세요 -->


## 📸 스크린 샷 (선택)
<img width="296" alt="image" src="https://github.com/user-attachments/assets/c1188dd1-0ca8-435f-8b0f-cd96da5b20d9" />


[EDMT-237]: https://bbangbbangz.atlassian.net/browse/EDMT-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 비밀번호를 변경할 수 있는 기능이 추가되었습니다. 비밀번호 변경 시 현재 비밀번호 불일치 또는 기존 비밀번호와 동일한 경우 각각의 오류 메시지가 제공됩니다.

* **문서**
  * 비밀번호 변경 관련 API 문서가 추가되어 성공 및 실패(비밀번호 불일치, 동일 비밀번호) 사례가 안내됩니다.

* **테스트**
  * 비밀번호 변경 성공 및 실패(현재 비밀번호 오류, 기존 비밀번호와 동일, 비밀번호 형식 오류) 시나리오에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->