### PR TITLE
[EDMT-252] 유저 이메일 변경 API 구현 

### DIFF
--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -39,3 +39,13 @@ operation::member/update-profile-fail/duplicated-nickname[snippets="http-respons
 ==== 성공
 
 operation::member/validate-nickname[snippets="request-headers,query-parameters,http-response,response-fields"]
+
+=== 이메일 수정
+
+==== 성공
+
+operation::member/update-email-success[snippets="request-headers,request-fields,http-response"]
+
+==== 실패: 유효하지 않은 이메일 형식
+
+operation::auth/find-password-fail/invalid-email-format[snippets="http-response"]

--- a/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
+++ b/src/main/java/com/edumate/eduserver/auth/facade/AuthFacade.java
@@ -11,7 +11,6 @@ import com.edumate.eduserver.auth.facade.response.MemberSignUpResponse;
 import com.edumate.eduserver.auth.jwt.TokenType;
 import com.edumate.eduserver.auth.service.AuthService;
 import com.edumate.eduserver.auth.service.PasswordValidator;
-import com.edumate.eduserver.auth.service.RandomCodeGenerator;
 import com.edumate.eduserver.auth.service.TokenService;
 import com.edumate.eduserver.external.aws.mail.EmailService;
 import com.edumate.eduserver.member.domain.Member;
@@ -35,13 +34,11 @@ public class AuthFacade {
     private final SubjectService subjectService;
     private final TokenService tokenService;
     private final PasswordEncoder passwordEncoder;
-    private final RandomCodeGenerator randomCodeGenerator;
     private final ApplicationEventPublisher eventPublisher;
 
     public void sendVerificationEmail(final long memberId) {
         Member member = memberService.getMemberById(memberId);
-        String verificationCode = randomCodeGenerator.generate();
-        authService.saveCode(member, verificationCode);
+        String verificationCode = authService.issueVerificationCode(member);
         emailService.sendEmail(member.getEmail(), member.getMemberUuid(), verificationCode);
     }
 
@@ -97,7 +94,7 @@ public class AuthFacade {
         String accessToken = tokenService.generateTokens(member, TokenType.ACCESS);
         String refreshToken = tokenService.generateTokens(member, TokenType.REFRESH);
         memberService.updateRefreshToken(member, refreshToken);
-        String authCode = issueVerificationCode(member);
+        String authCode = authService.issueVerificationCode(member);
         eventPublisher.publishEvent(MemberSignedUpEvent.of(member.getEmail(), member.getMemberUuid(), authCode));
         return MemberSignUpResponse.of(accessToken, refreshToken);
     }
@@ -115,12 +112,6 @@ public class AuthFacade {
         } catch (DataIntegrityViolationException e) {
             throw new MemberAlreadyRegisteredException(AuthErrorCode.MEMBER_ALREADY_REGISTERED);
         }
-    }
-
-    private String issueVerificationCode(final Member member) {
-        String code = randomCodeGenerator.generate();
-        authService.saveCode(member, code);
-        return code;
     }
 
     @Transactional

--- a/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
+++ b/src/main/java/com/edumate/eduserver/auth/service/AuthService.java
@@ -26,6 +26,7 @@ public class AuthService {
     private final AuthorizationCodeRepository authorizationCodeRepository;
     private final MemberRepository memberRepository;
     private final ValidEmailRepository validEmailRepository;
+    private final RandomCodeGenerator randomCodeGenerator;
 
     private static final String EMPTY_REFRESH_TOKEN = null;
     private static final boolean NOT_DELETED = false;
@@ -54,6 +55,13 @@ public class AuthService {
         if (!validEmails.contains(domain)) {
             throw new InvalidEmailDomainException(AuthErrorCode.INVALID_EMAIL);
         }
+    }
+
+    @Transactional
+    public String issueVerificationCode(final Member member) {
+        String code = randomCodeGenerator.generate();
+        saveCode(member, code);
+        return code;
     }
 
     private String extractEmailDomain(final String email) {

--- a/src/main/java/com/edumate/eduserver/external/aws/mail/EmailService.java
+++ b/src/main/java/com/edumate/eduserver/external/aws/mail/EmailService.java
@@ -20,8 +20,16 @@ public class EmailService {
     private final AwsSesEmailMapper awsSesEmailMapper;
 
     public void sendEmail(final String emailReceiver, final String memberUuid, final String verificationCode) {
-        String htmlBody = awsSesEmailMapper.buildEmailBody(memberUuid, verificationCode);
-        SendEmailRequest request = awsSesEmailMapper.buildSendEmailRequest(emailReceiver, htmlBody);
+        SendEmailRequest request = awsSesEmailMapper.buildEmailRequest(emailReceiver, memberUuid, verificationCode);
+        send(request, emailReceiver, memberUuid);
+    }
+
+    public void sendEmailForEmailUpdate(final String emailReceiver, final String memberUuid, final String verificationCode) {
+        SendEmailRequest request = awsSesEmailMapper.buildEmailRequestForEmailUpdate(emailReceiver, memberUuid, verificationCode);
+        send(request, emailReceiver, memberUuid);
+    }
+
+    private void send(final SendEmailRequest request, final String emailReceiver, final String memberUuid) {
         log.info("[SES] 이메일 발송 요청: to={}, memberUuid={}", emailReceiver, memberUuid);
         SendEmailResponse result = sesClient.sendEmail(request);
         log.info("[SES] 이메일 발송 응답: to={}, messageId={}, status={} ", emailReceiver, result.messageId(), result.sdkHttpResponse().statusCode());

--- a/src/main/java/com/edumate/eduserver/external/aws/mail/event/EmailEventListener.java
+++ b/src/main/java/com/edumate/eduserver/external/aws/mail/event/EmailEventListener.java
@@ -2,6 +2,7 @@ package com.edumate.eduserver.external.aws.mail.event;
 
 import com.edumate.eduserver.auth.facade.dto.MemberSignedUpEvent;
 import com.edumate.eduserver.external.aws.mail.EmailService;
+import com.edumate.eduserver.member.facade.dto.MemberEmailUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -23,6 +24,16 @@ public class EmailEventListener {
             emailService.sendEmail(event.email(), event.memberUuid(), event.verificationCode());
         } catch (Exception e) {
             log.error("이메일 발송 실패. event={} message={}", event, e.getMessage());
+        }
+    }
+
+    @Async("emailTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEmailUpdatedEvent(final MemberEmailUpdatedEvent event) {
+        try {
+            emailService.sendEmailForEmailUpdate(event.email(), event.memberUuid(), event.verificationCode());
+        } catch (Exception e) {
+            log.error("이메일 변경 후 메일 발송 실패. event={} message={}", event, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/edumate/eduserver/member/controller/MemberController.java
+++ b/src/main/java/com/edumate/eduserver/member/controller/MemberController.java
@@ -3,8 +3,9 @@ package com.edumate.eduserver.member.controller;
 import com.edumate.eduserver.common.ApiResponse;
 import com.edumate.eduserver.common.annotation.MemberId;
 import com.edumate.eduserver.common.code.CommonSuccessCode;
-import com.edumate.eduserver.member.controller.request.PasswordChangeRequest;
+import com.edumate.eduserver.member.controller.request.MemberEmailUpdateRequest;
 import com.edumate.eduserver.member.controller.request.MemberProfileUpdateRequest;
+import com.edumate.eduserver.member.controller.request.PasswordChangeRequest;
 import com.edumate.eduserver.member.domain.School;
 import com.edumate.eduserver.member.facade.MemberFacade;
 import com.edumate.eduserver.member.facade.response.MemberNicknameValidationResponse;
@@ -44,7 +45,6 @@ public class MemberController {
     ) {
         School school = School.fromName(request.school());
         memberFacade.updateMemberProfile(memberId, request.subject(), school, request.nickname());
-
         return ApiResponse.success(CommonSuccessCode.OK);
     }
 
@@ -54,5 +54,14 @@ public class MemberController {
             @RequestParam final String nickname
     ) {
         return ApiResponse.success(CommonSuccessCode.OK, memberFacade.validateNickname(memberId, nickname));
+    }
+
+    @PatchMapping("/email")
+    public ApiResponse<Void> updateEmail(
+            @MemberId final long memberId,
+            @RequestBody final MemberEmailUpdateRequest request
+    ) {
+        memberFacade.updateEmail(memberId, request.email());
+        return ApiResponse.success(CommonSuccessCode.OK);
     }
 }

--- a/src/main/java/com/edumate/eduserver/member/controller/MemberController.java
+++ b/src/main/java/com/edumate/eduserver/member/controller/MemberController.java
@@ -59,7 +59,7 @@ public class MemberController {
     @PatchMapping("/email")
     public ApiResponse<Void> updateEmail(
             @MemberId final long memberId,
-            @RequestBody final MemberEmailUpdateRequest request
+            @RequestBody @Valid final MemberEmailUpdateRequest request
     ) {
         memberFacade.updateEmail(memberId, request.email());
         return ApiResponse.success(CommonSuccessCode.OK);

--- a/src/main/java/com/edumate/eduserver/member/controller/request/MemberEmailUpdateRequest.java
+++ b/src/main/java/com/edumate/eduserver/member/controller/request/MemberEmailUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.member.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberEmailUpdateRequest(
+        @NotNull(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email
+) {
+}

--- a/src/main/java/com/edumate/eduserver/member/domain/Member.java
+++ b/src/main/java/com/edumate/eduserver/member/domain/Member.java
@@ -138,4 +138,12 @@ public class Member extends BaseEntity {
         this.school = school;
         this.nickname = nickname;
     }
+
+    public void updateEmail(final String email) {
+        this.email = email;
+    }
+
+    public void updateRole(final Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/edumate/eduserver/member/facade/dto/MemberEmailUpdatedEvent.java
+++ b/src/main/java/com/edumate/eduserver/member/facade/dto/MemberEmailUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.edumate.eduserver.member.facade.dto;
+
+public record MemberEmailUpdatedEvent(
+        String email,
+        String memberUuid,
+        String verificationCode
+) {
+    public static MemberEmailUpdatedEvent of(final String email, final String memberUuid, final String verificationCode) {
+        return new MemberEmailUpdatedEvent(email, memberUuid, verificationCode);
+    }
+}

--- a/src/main/java/com/edumate/eduserver/member/service/MemberService.java
+++ b/src/main/java/com/edumate/eduserver/member/service/MemberService.java
@@ -97,17 +97,16 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateMemberProfile(final long memberId, final Subject subject, final School school, final String nickname) {
-        Member member = getMemberById(memberId);
-        validateNickname(memberId, nickname);
+    public void updateMemberProfile(final Member member, final Subject subject, final School school, final String nickname) {
+        validateNickname(member, nickname);
         member.updateProfile(subject, school, nickname);
     }
 
-    private void validateNickname(final long memberId, final String nickname) {
+    private void validateNickname(final Member member, final String nickname) {
         if (isNicknameInvalid(nickname)) {
             throw new MemberNicknameInvalidException(MemberErrorCode.INVALID_NICKNAME, nickname);
         }
-        if (isNicknameDuplicated(memberId, nickname)) {
+        if (isNicknameDuplicated(member, nickname)) {
             throw new MemberNicknameDuplicateException(MemberErrorCode.DUPLICATED_NICKNAME, nickname);
         }
     }
@@ -118,7 +117,17 @@ public class MemberService {
                 || nicknameBannedWordRepository.existsBannedWordIn(nickname);
     }
 
-    public boolean isNicknameDuplicated(final long memberId, final String nickname) {
-        return memberRepository.existsByIdNotAndNicknameIgnoreCaseAndIsDeleted(memberId, nickname, NOT_DELETED);
+    public boolean isNicknameDuplicated(final Member member, final String nickname) {
+        return memberRepository.existsByIdNotAndNicknameIgnoreCaseAndIsDeleted(member.getId(), nickname, NOT_DELETED);
+    }
+
+    @Transactional
+    public void updateEmail(final Member member, String email) {
+        member.updateEmail(email);
+    }
+
+    @Transactional
+    public void setRolePendingTeacher(final Member member) {
+        member.updateRole(Role.PENDING_TEACHER);
     }
 }

--- a/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacade.java
@@ -65,7 +65,8 @@ public class StudentRecordFacade {
     @Transactional
     public void createStudentRecord(final long memberId, final StudentRecordType recordType, final String semester,
                                     final StudentRecordCreateInfo studentRecordCreateInfo) {
-        studentRecordService.createStudentRecord(memberId, recordType, semester, studentRecordCreateInfo);
+        Member member = memberService.getMemberById(memberId);
+        studentRecordService.createStudentRecord(member, recordType, semester, studentRecordCreateInfo);
     }
 
     @Transactional

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -98,6 +98,21 @@ public class StudentRecordService {
                 studentRecordCreateInfo.description(), studentRecordCreateInfo.byteCount());
         return studentRecordDetailRepository.save(studentRecordDetail);
     }
+    @Transactional
+    public StudentRecordDetail createStudentRecord(final Member member, final StudentRecordType recordType,
+                                                   final String semester,
+                                                   final StudentRecordCreateInfo studentRecordCreateInfo) {
+        validateSemesterPattern(semester);
+        RecordMetadata recordMetadata = findRecordMetaData(member.getId(), recordType, semester)
+                .orElseGet(() -> {
+                    RecordMetadata newRecord = RecordMetadata.create(member, recordType, semester);
+                    return recordMetadataRepository.save(newRecord);
+                });
+        StudentRecordDetail studentRecordDetail = StudentRecordDetail.create(recordMetadata,
+                studentRecordCreateInfo.studentNumber(), studentRecordCreateInfo.studentName(),
+                studentRecordCreateInfo.description(), studentRecordCreateInfo.byteCount());
+        return studentRecordDetailRepository.save(studentRecordDetail);
+    }
 
     @Transactional
     public void updateStudentRecordOverview(final long memberId, final long recordId, final String studentNumber,

--- a/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
+++ b/src/main/java/com/edumate/eduserver/studentrecord/service/StudentRecordService.java
@@ -88,17 +88,6 @@ public class StudentRecordService {
     }
 
     @Transactional
-    public StudentRecordDetail createStudentRecord(final long memberId, final StudentRecordType recordType,
-                                                   final String semester,
-                                                   final StudentRecordCreateInfo studentRecordCreateInfo) {
-        validateSemesterPattern(semester);
-        RecordMetadata recordMetadata = getMemberStudentRecord(memberId, recordType, semester);
-        StudentRecordDetail studentRecordDetail = StudentRecordDetail.create(recordMetadata,
-                studentRecordCreateInfo.studentNumber(), studentRecordCreateInfo.studentName(),
-                studentRecordCreateInfo.description(), studentRecordCreateInfo.byteCount());
-        return studentRecordDetailRepository.save(studentRecordDetail);
-    }
-    @Transactional
     public StudentRecordDetail createStudentRecord(final Member member, final StudentRecordType recordType,
                                                    final String semester,
                                                    final StudentRecordCreateInfo studentRecordCreateInfo) {

--- a/src/main/resources/templates/update-email-verification.html
+++ b/src/main/resources/templates/update-email-verification.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>이메일 변경 인증</title>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap" rel="stylesheet">
+    <style>
+        .verification-button {
+            display: inline-block;
+            padding: 12px 24px;
+            background-color: #0d6efd;
+            color: #fff !important;
+            text-decoration: none;
+            border-radius: 6px;
+            margin-top: 20px;
+            font-weight: bold;
+            transition: background-color 0.3s ease;
+        }
+
+        .verification-button:hover {
+            background-color: #0b5ed7 !important;
+        }
+    </style>
+</head>
+<body style="font-family: 'Noto Sans KR', sans-serif; background-color: #f1f3f5; padding: 30px;">
+<div style="
+    max-width: 600px;
+    margin: auto;
+    background: #ffffff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+">
+    <h2 style="color: #212529; margin-bottom: 10px;">📧 이메일 변경 확인</h2>
+    <p style="color: #495057; margin-top: 0;">안녕하세요, 선생님.</p>
+    <p style="color: #495057;">
+        새로운 이메일로 변경이 완료되었습니다.
+    </p>
+    <p style="color: #495057;">
+        계속 서비스를 이용하시려면 아래 <strong>‘이메일 인증하기’</strong> 버튼을 눌러 인증을 진행해 주세요.
+    </p>
+
+    <a th:href="${verificationLink}" class="verification-button">이메일 인증하기</a>
+</div>
+</body>
+</html>

--- a/src/test/java/com/edumate/eduserver/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/edumate/eduserver/member/controller/MemberControllerTest.java
@@ -22,13 +22,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.edumate.eduserver.auth.exception.InvalidPasswordLengthException;
 import com.edumate.eduserver.auth.exception.code.AuthErrorCode;
 import com.edumate.eduserver.docs.CustomRestDocsUtils;
+import com.edumate.eduserver.member.controller.request.MemberEmailUpdateRequest;
+import com.edumate.eduserver.member.controller.request.MemberProfileUpdateRequest;
 import com.edumate.eduserver.member.controller.request.PasswordChangeRequest;
 import com.edumate.eduserver.member.domain.School;
 import com.edumate.eduserver.member.exception.InvalidPasswordException;
-import com.edumate.eduserver.member.exception.PasswordSameAsOldException;
-import com.edumate.eduserver.member.controller.request.MemberProfileUpdateRequest;
 import com.edumate.eduserver.member.exception.MemberNicknameDuplicateException;
 import com.edumate.eduserver.member.exception.MemberNicknameInvalidException;
+import com.edumate.eduserver.member.exception.PasswordSameAsOldException;
 import com.edumate.eduserver.member.exception.code.MemberErrorCode;
 import com.edumate.eduserver.member.facade.MemberFacade;
 import com.edumate.eduserver.member.facade.response.MemberNicknameValidationResponse;
@@ -330,6 +331,37 @@ class MemberControllerTest extends ControllerTest {
                                 fieldWithPath("message").description("응답 메시지"),
                                 fieldWithPath("data.isInvalid").description("유효하지 않은 닉네임 여부"),
                                 fieldWithPath("data.isDuplicated").description("중복된 닉네임 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("이메일을 성공적으로 수정한다.")
+    void updateEmailSuccess() throws Exception {
+        // given
+        MemberEmailUpdateRequest request = new MemberEmailUpdateRequest("newemail@test.com");
+        doNothing().when(memberFacade).updateEmail(anyLong(), anyString());
+
+        // when & then
+        mockMvc.perform(patch(BASE_URL + "/email")
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("EDMT-200"))
+                .andExpect(jsonPath("$.message").value("요청이 성공했습니다."))
+                .andDo(CustomRestDocsUtils.documents(BASE_DOMAIN_PACKAGE + "update-email-success",
+                        requestHeaders(
+                                headerWithName("Authorization").description("액세스 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("email").description("새 이메일 주소")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("HTTP 상태 코드"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지")
                         )
                 ));
     }

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 
 import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
-import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.RecordMetadata;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
@@ -121,19 +120,6 @@ class StudentRecordFacadeTest {
         verify(memberService).getMemberById(memberId);
         verify(studentRecordService).createOrGetSemesterRecord(mockMember, type, semester);
         verify(studentRecordService).createStudentRecords(mockRecord, studentRecordInfos);
-    }
-
-    @Test
-    @DisplayName("학생 기록 생성이 정상 동작한다.")
-    void createStudentRecord() {
-        long memberId = 500L;
-        StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
-        String semester = "2024-2";
-        StudentRecordCreateInfo info = mock(StudentRecordCreateInfo.class);
-
-        studentRecordFacade.createStudentRecord(memberId, type, semester, info);
-
-        verify(studentRecordService).createStudentRecord(memberId, type, semester, info);
     }
 
     @Test

--- a/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/facade/StudentRecordFacadeTest.java
@@ -5,9 +5,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.member.service.MemberService;
+import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.RecordMetadata;
 import com.edumate.eduserver.studentrecord.domain.StudentRecordDetail;
@@ -120,6 +122,22 @@ class StudentRecordFacadeTest {
         verify(memberService).getMemberById(memberId);
         verify(studentRecordService).createOrGetSemesterRecord(mockMember, type, semester);
         verify(studentRecordService).createStudentRecords(mockRecord, studentRecordInfos);
+    }
+
+    @Test
+    @DisplayName("학생 기록 생성이 정상 동작한다.")
+    void createStudentRecord() {
+        long memberId = 500L;
+        StudentRecordType type = StudentRecordType.ABILITY_DETAIL;
+        String semester = "2024-2";
+        StudentRecordCreateInfo info = mock(StudentRecordCreateInfo.class);
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(memberId);
+        given(memberService.getMemberById(memberId)).willReturn(member);
+
+        studentRecordFacade.createStudentRecord(memberId, type, semester, info);
+
+        verify(studentRecordService).createStudentRecord(member, type, semester, info);
     }
 
     @Test

--- a/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
+++ b/src/test/java/com/edumate/eduserver/studentrecord/service/StudentRecordServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.edumate.eduserver.member.domain.Member;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordCreateInfo;
 import com.edumate.eduserver.studentrecord.controller.request.vo.StudentRecordInfo;
 import com.edumate.eduserver.studentrecord.domain.RecordMetadata;
@@ -140,9 +143,11 @@ class StudentRecordServiceTest extends ServiceTest {
         StudentRecordCreateInfo studentRecordCreateInfo = StudentRecordCreateInfo.of(
                 studentNumber, studentName, description, byteCount
         );
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(memberId);
 
         // when
-        StudentRecordDetail studentRecord = studentRecordService.createStudentRecord(memberId, recordType, semester,
+        StudentRecordDetail studentRecord = studentRecordService.createStudentRecord(member, recordType, semester,
                 studentRecordCreateInfo);
 
         // then
@@ -170,11 +175,13 @@ class StudentRecordServiceTest extends ServiceTest {
         String originalStudentName = "유태근";
         String originalDescription = "기존 내용";
         int originalByteCount = 22;
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(memberId);
 
         StudentRecordCreateInfo createInfo = StudentRecordCreateInfo.of(
                 originalStudentNumber, originalStudentName, originalDescription, originalByteCount
         );
-        StudentRecordDetail savedRecord = studentRecordService.createStudentRecord(memberId, recordType, semester, createInfo);
+        StudentRecordDetail savedRecord = studentRecordService.createStudentRecord(member, recordType, semester, createInfo);
         long recordId = savedRecord.getId();
 
         String updatedStudentNumber = "2023111";
@@ -242,8 +249,10 @@ class StudentRecordServiceTest extends ServiceTest {
         StudentRecordType recordType = StudentRecordType.ABILITY_DETAIL;
         String semester = "2025-1";
         StudentRecordCreateInfo info = StudentRecordCreateInfo.of("2023002", "유태근", "삭제될 생기부", 22);
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(memberId);
 
-        StudentRecordDetail created = studentRecordService.createStudentRecord(memberId, recordType, semester, info);
+        StudentRecordDetail created = studentRecordService.createStudentRecord(member, recordType, semester, info);
         long recordId = created.getId();
 
         // when


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-252]

## 👩‍💻 작업 내용

<!-- 작업 내용을 적어주세요 -->
마이페이지에서 유저의 이메일을 변경하는 API를 구현했습니다.
또한, 변경 후에는 유저의 상태를 PENDING_TEACHER으로 수정하고 교사 인증을 위한 이메일을 발송합니다.

[EDMT-252]: https://bbangbbangz.atlassian.net/browse/EDMT-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원 이메일 변경 기능이 추가되었습니다. 이메일 변경 시 인증 메일이 발송됩니다.
  * 이메일 변경 API 엔드포인트가 추가되었습니다.
  * 이메일 변경에 대한 API 문서 및 예외 케이스가 문서에 반영되었습니다.

* **버그 수정**
  * 해당 없음

* **문서**
  * 이메일 변경 관련 API 문서가 확장되었습니다.

* **테스트**
  * 이메일 변경 성공에 대한 컨트롤러 테스트가 추가되었습니다.
  * 학생 기록 생성 관련 테스트가 제거되었습니다.

* **리팩터**
  * 이메일 인증 메일 발송 로직이 개선되어 다양한 상황에 맞는 템플릿과 제목을 지원합니다.
  * 회원 정보 및 학생 기록 관련 서비스/파사드 계층의 객체 전달 방식이 개선되었습니다.

* **스타일**
  * 이메일 변경 인증을 위한 새로운 HTML 이메일 템플릿이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->