### PR TITLE
[EDMT-204] 프로메테우스 메트릭 수집 경로를 인증 필터 제외

### DIFF
--- a/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
@@ -50,8 +50,7 @@ public class SecurityConfig {
             "/api/v1/auth/verify-email",
             "/api/v1/auth/find-password",
             "/actuator/health",
-            "/actuator/prometheus",
-            "/actuator/info"
+            "/actuator/prometheus"
     };
     private static final String[] BUSINESS_WHITE_LIST = {
             "/api/v1/notices",

--- a/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
             "/api/v1/auth/password",
             "/api/v1/auth/verify-email",
             "/api/v1/auth/find-password",
-            "/actuator/health"
+            "/actuator/health",
+            "/actuator/prometheus"
     };
     private static final String[] BUSINESS_WHITE_LIST = {
             "/api/v1/notices",

--- a/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
+++ b/src/main/java/com/edumate/eduserver/common/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
             "/api/v1/auth/verify-email",
             "/api/v1/auth/find-password",
             "/actuator/health",
-            "/actuator/prometheus"
+            "/actuator/prometheus",
+            "/actuator/info"
     };
     private static final String[] BUSINESS_WHITE_LIST = {
             "/api/v1/notices",


### PR DESCRIPTION
## 📣 Jira Ticket
<!-- 지라 티켓 번호를 작성해주세요 -->
[EDMT-204]

## 👩‍💻 작업 내용
/actuator/prometheus 엔드포인트에 대해 인증 필터를 적용하지 않도록 설정하여 외부 Prometheus 서버가 인증 없이 메트릭 수집 가능하도록 변경

[EDMT-204]: https://bbangbbangz.atlassian.net/browse/EDMT-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * "/actuator/prometheus" 엔드포인트에 대한 인증 없이 접근이 가능하도록 허용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->